### PR TITLE
Restrict indexes in dependency monkey runs

### DIFF
--- a/thoth/adviser/python/advise.py
+++ b/thoth/adviser/python/advise.py
@@ -77,7 +77,7 @@ class Adviser:
         dry_run: bool = False,
     ) -> typing.Union[typing.List[Project], int]:
         """Compute recommendations for the given project."""
-        dependency_graph = DependencyGraph.from_project(graph, project)
+        dependency_graph = DependencyGraph.from_project(graph, project, restrict_indexes=False)
 
         try:
             for decision_function_result, generated_project in dependency_graph.walk(

--- a/thoth/adviser/python/dependency_monkey.py
+++ b/thoth/adviser/python/dependency_monkey.py
@@ -88,7 +88,7 @@ def _do_dependency_monkey(
     dry_run: bool = False,
 ) -> dict:
     """Run dependency monkey."""
-    dependency_graph = DependencyGraph.from_project(graph, project)
+    dependency_graph = DependencyGraph.from_project(graph, project, restrict_indexes=True)
 
     computed = 0
     result = {"output": [], "computed": 0}


### PR DESCRIPTION
This way we can say dependency monkey to generate software stacks considering
only some indexes (not all registered to Thoth).