### PR TITLE
added the Registry to be used for image pulling to the templates

### DIFF
--- a/openshift/job-adviser-template.yaml
+++ b/openshift/job-adviser-template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     description: "Thoth: Adviser"
     openshift.io/display-name: "Thoth: Adviser"
-    version: 0.4.1
+    version: 0.4.2
     tags: thoth,ai-stacks,adviser
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
     template.openshift.io/long-description: >
@@ -17,6 +17,12 @@ metadata:
     component: adviser
 
 parameters:
+  - description: Registry the ImageStream to be use lives in
+    displayName: ImageStream Registry
+    required: true
+    name: IMAGE_STREAM_REGISTRY
+    value: "docker-registry.default.svc:5000"
+
   - description: Project the ImageStream to be use lives in
     displayName: ImageStream Project
     required: true
@@ -104,7 +110,7 @@ objects:
           automountServiceAccountToken: false
           containers:
             - name: adviser
-              image: "${IMAGE_STREAM_NAMESPACE}/adviser:${IMAGE_STREAM_TAG}"
+              image: "${IMAGE_STREAM_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/adviser:${IMAGE_STREAM_TAG}"
               livenessProbe:
                 # Give analyzer specified seconds to compute results, kill
                 # stack producer so the main process reports scored results.

--- a/openshift/job-dependencyMonkey-template.yaml
+++ b/openshift/job-dependencyMonkey-template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     description: "Thoth: Dependency Monkey"
     openshift.io/display-name: "Thoth: Dependency Monkey"
-    version: 0.4.1
+    version: 0.4.2
     tags: thoth,ai-stacks,dependency-monkey
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
     template.openshift.io/long-description: >
@@ -17,6 +17,12 @@ metadata:
     component: dependency-monkey
 
 parameters:
+  - description: Registry the ImageStream to be use lives in
+    displayName: ImageStream Registry
+    required: true
+    name: IMAGE_STREAM_REGISTRY
+    value: "docker-registry.default.svc:5000"
+
   - description: Project the ImageStream to be use lives in
     displayName: ImageStream Project
     required: true
@@ -106,7 +112,7 @@ objects:
           automountServiceAccountToken: false
           containers:
             - name: dependency-monkey
-              image: "${IMAGE_STREAM_NAMESPACE}/adviser:${IMAGE_STREAM_TAG}"
+              image: "${IMAGE_STREAM_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/adviser:${IMAGE_STREAM_TAG}"
               livenessProbe:
                 # Give analyzer 30 minutes to compute results, kill it if it was not able result anything.
                 tcpSocket:

--- a/openshift/job-provenanceChecker-template.yaml
+++ b/openshift/job-provenanceChecker-template.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     description: "Thoth: Provenance Checker"
     openshift.io/display-name: "Thoth: Provenance Checker"
-    version: 0.4.1
+    version: 0.4.2
     tags: thoth,ai-stacks,provenance-checker
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
     template.openshift.io/long-description: >
@@ -17,6 +17,12 @@ metadata:
     component: provenance-checker
 
 parameters:
+  - description: Registry the ImageStream to be use lives in
+    displayName: ImageStream Registry
+    required: true
+    name: IMAGE_STREAM_REGISTRY
+    value: "docker-registry.default.svc:5000"
+
   - description: Project the ImageStream to be use lives in
     displayName: ImageStream Project
     required: true
@@ -77,7 +83,7 @@ objects:
           automountServiceAccountToken: false
           containers:
             - name: provenance-checker
-              image: "${IMAGE_STREAM_NAMESPACE}/adviser:${IMAGE_STREAM_TAG}"
+              image: "${IMAGE_STREAM_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/adviser:${IMAGE_STREAM_TAG}"
               livenessProbe:
                 # Give analyzer 10 minutes to compute results, kill it if it was not able result anything.
                 tcpSocket:


### PR DESCRIPTION
As we are creating Jobs, OpenShift needs to know from which Registry the images should be pulled, as it assumes docker.io if none is provided.

https://github.com/openshift/origin/pull/13210 might be related.

Signed-off-by: Christoph Görn <goern@redhat.com>