### PR TITLE
Added the method to read version from project library to conf.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
     command_options={
         'build_sphinx': {
             'version': ('setup.py', VERSION),
+            'release': ('setup.py', VERSION),
         }
     }
 )


### PR DESCRIPTION
Fixes: #233 

The PR contains:
- A method which reads a version from the project library and feeds it to conf.py.
Tested with cmd: `sphinx-build docs/source <destination>`
-  Some Pep8 changes.