### PR TITLE
Do not depend on specific graph adapter from specific module

### DIFF
--- a/thoth/adviser/python/bin/dependency_graph.py
+++ b/thoth/adviser/python/bin/dependency_graph.py
@@ -251,7 +251,7 @@ class DependencyGraph:
             os.close(write_fd)
 
         # This is a really dirty hack, but it is required. We need to wait for parent to finish as queries to the
-        # JanusGraph are done in async coroutines. If the stack producer process finishes sooner, we get stuck in the
+        # graph db are done in async coroutines. If the stack producer process finishes sooner, we get stuck in the
         # event loop which is halted due to SIGCHILD signal. Obviously, child cannot wait for parent in
         # waitpid call (in a POSIX compliant way), so we send SIGSTOP to self (stack producer process) and wait
         # for parent to finish passively so we are out of OS process scheduler. Once the parent finishes

--- a/thoth/adviser/python/solver.py
+++ b/thoth/adviser/python/solver.py
@@ -51,7 +51,7 @@ class GraphReleasesFetcher(ReleasesFetcher):
     def graph_db(self):
         """Get instance of graph database adapter, lazily."""
         # Place the import statement here to simplify mocks in the testsuite.
-        from thoth.storages.graph.janusgraph import GraphDatabase
+        from thoth.storages import GraphDatabase
 
         if not self._graph_db:
             self._graph_db = GraphDatabase()


### PR DESCRIPTION
This way we pick implementation present - simplifies transition to Dgraph.