### PR TITLE
Remove is_solvable flag as done in Dgraph implementation

### DIFF
--- a/thoth/adviser/cli.py
+++ b/thoth/adviser/cli.py
@@ -377,7 +377,8 @@ def advise(
         result["advised_configuration"] = advised_configuration
         # Convert report to a dict so its serialized.
         result["report"] = [
-            (justification, project.to_dict()) for justification, project in report
+            (justification, project.to_dict(), overall_score)
+            for justification, project, overall_score in report
         ]
 
     print_command_result(

--- a/thoth/adviser/python/pipeline/pipeline.py
+++ b/thoth/adviser/python/pipeline/pipeline.py
@@ -116,7 +116,7 @@ class Pipeline:
         seen_ids = ids_map.keys()
         unseen_ids = set()
         for entry in transitive_dependencies:
-            for idx in range(0, len(entry), 2):
+            for idx in range(len(entry)):
                 if entry[idx] not in seen_ids:
                     unseen_ids.add(entry[idx])
 
@@ -134,10 +134,7 @@ class Pipeline:
         for entries in transitive_dependencies:
             new_entries = []
             for idx, entry in enumerate(entries):
-                if idx % 2 == 0:
-                    # TODO: remove "is_solvable" flag from query
-                    new_entries.append(ids_map[entry])
-
+                new_entries.append(ids_map[entry])
             result.append(new_entries)
 
         return result


### PR DESCRIPTION
Depends-On: https://github.com/thoth-station/storages/pull/598

With the transition to Dgraph, there are no flags propagated to the adviser. The reasoning behind it - optimize the query (not to have issues with serialization) and we should move this into the adviser step anyway.