### PR TITLE
Optimize retrieval of transitive dependencies to avoid list copies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,17 @@ def read(fname):
 
 
 class Test(TestCommand):
+    """Introduce test command to run testsuite using pytest."""
+
+    _IMPLICIT_PYTEST_ARGS = ['tests/', '--timeout=2', '--cov=./thoth', '--capture=no', '--verbose', '-l', '-s', '-vv']
+
     user_options = [
         ('pytest-args=', 'a', "Arguments to pass into py.test")
     ]
 
     def initialize_options(self):
         super().initialize_options()
-        self.pytest_args = ['tests/', '--timeout=2', '--cov=./thoth', '--capture=no', '--verbose', '-l', '-s', '-vv']
+        self.pytest_args = None
 
     def finalize_options(self):
         super().finalize_options()
@@ -41,7 +45,13 @@ class Test(TestCommand):
 
     def run_tests(self):
         import pytest
-        sys.exit(pytest.main(self.pytest_args))
+        passed_args = list(self._IMPLICIT_PYTEST_ARGS)
+
+        if self.pytest_args:
+            self.pytest_args = [arg for arg in self.pytest_args.split() if arg]
+            passed_args.extend(self.pytest_args)
+
+        sys.exit(pytest.main(passed_args))
 
 
 VERSION = get_version()

--- a/tests/python/pipeline/steps/test_buildtime_error.py
+++ b/tests/python/pipeline/steps/test_buildtime_error.py
@@ -44,25 +44,21 @@ class TestBuildtimeErrorFiltering(AdviserTestCase):
 
     @staticmethod
     def _get_prepared_context():
-        direct_dependencies = [
-            PackageVersion(
+        direct_dependencies = {
+            ("flask", "0.12.0", "https://pypi.org/simple"): PackageVersion(
                 name="flask",
                 version="==0.12.0",
                 index=Source("https://pypi.org/simple"),
                 develop=False,
-            ),
-        ]
+            )
+        }
 
-        paths = [
-            [
-                ("flask", "0.12.0", "https://pypi.org/simple"),
-                ("click", "2.0", "https://pypi.org/simple"),
+        paths = {
+            ("flask", "0.12.0", "https://pypi.org/simple"): [
+                (("flask", "0.12.0", "https://pypi.org/simple"), ("click", "2.0", "https://pypi.org/simple")),
+                (("flask", "0.12.0", "https://pypi.org/simple"), ("click", "2.1", "https://pypi.org/simple")),
             ],
-            [
-                ("flask", "0.12.0", "https://pypi.org/simple"),
-                ("click", "2.1", "https://pypi.org/simple"),
-            ],
-        ]
+        }
 
         return StepContext.from_paths(direct_dependencies, paths)
 

--- a/tests/python/pipeline/steps/test_limit_latest_versions.py
+++ b/tests/python/pipeline/steps/test_limit_latest_versions.py
@@ -32,31 +32,33 @@ class TestLimitLatestVersions(AdviserTestCase):
 
     def test_limit_direct(self):
         """Test cutting off latest versions for a direct dependency of a type."""
-        direct_dependencies = [
-            PackageVersion(
+        index_aicoe =Source("https://thoth-station.ninja/simple")
+
+        direct_dependencies = {
+            ("tensorflow", "1.9.0", index_aicoe.url): PackageVersion(
                 name="tensorflow",
                 version="==1.9.0",
-                index=Source("https://thoth-station.ninja/simple"),
+                index=index_aicoe,
                 develop=False,
             ),
-            PackageVersion(
+            ("tensorflow", "2.0.0", index_aicoe.url): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
                 index=Source("https://thoth-station.ninja/simple"),
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [
-                ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"): [
+                (("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
+                 ("numpy", "1.0.0", "https://pypi.org/simple"))
             ],
-            [
-                ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
+            ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"): [
+                (("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
+                ("numpy", "1.0.0", "https://pypi.org/simple")),
             ],
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
@@ -95,25 +97,25 @@ class TestLimitLatestVersions(AdviserTestCase):
 
     def test_limit_transitive(self):
         """Test cutting of latest versions for transitive dependencies."""
-        direct_dependencies = [
-            PackageVersion(
+        direct_dependencies = {
+            ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
                 index=Source("https://thoth-station.ninja/simple"),
                 develop=False,
             )
-        ]
+        }
 
-        paths = [
-            [
-                ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"): [
+                (("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
+                ("numpy", "1.0.0", "https://pypi.org/simple")),
             ],
-            [
-                ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
+            ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"): [
+                (("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
+                ("numpy", "2.0.0", "https://pypi.org/simple")),
             ],
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
@@ -152,39 +154,36 @@ class TestLimitLatestVersions(AdviserTestCase):
 
     def test_limit_all(self):
         """Test cutting of latest versions for direct and transitive dependencies."""
-        direct_dependencies = [
-            PackageVersion(
+        source = Source("https://thoth-station.ninja/simple")
+        direct_dependencies = {
+            ("tensorflow", "1.9.0", source.url): PackageVersion(
                 name="tensorflow",
                 version="==1.9.0",
-                index=Source("https://thoth-station.ninja/simple"),
+                index=source,
                 develop=False,
             ),
-            PackageVersion(
+            ("tensorflow", "2.0.0", source.url): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
                 index=Source("https://thoth-station.ninja/simple"),
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [
-                ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"): [
+                (("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
+                 ("numpy", "1.0.0", "https://pypi.org/simple")),
+                (("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
+                 ("numpy", "2.0.0", "https://pypi.org/simple")),
             ],
-            [
-                ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
-            ],
-            [
-                ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
-            ],
-            [
-                ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
-            ],
-        ]
+            ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"): [
+                (("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
+                 ("numpy", "1.0.0", "https://pypi.org/simple")),
+                (("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
+                 ("numpy", "2.0.0", "https://pypi.org/simple")),
+            ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
@@ -223,39 +222,37 @@ class TestLimitLatestVersions(AdviserTestCase):
 
     def test_limit_no_change(self):
         """Test cutting off latest versions without any change."""
-        direct_dependencies = [
-            PackageVersion(
+        source = Source("https://thoth-station.ninja/simple")
+        direct_dependencies = {
+            ("tensorflow", "1.9.0", source.url): PackageVersion(
                 name="tensorflow",
                 version="==1.9.0",
-                index=Source("https://thoth-station.ninja/simple"),
+                index=source,
                 develop=False,
             ),
-            PackageVersion(
+            ("tensorflow", "2.0.0", source.url): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
-                index=Source("https://thoth-station.ninja/simple"),
+                index=source,
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [
-                ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"): [
+                (("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
+                 ("numpy", "1.0.0", "https://pypi.org/simple")),
+                (("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
+                 ("numpy", "2.0.0", "https://pypi.org/simple")),
             ],
-            [
-                ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
-            ],
-            [
-                ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
-            ],
-            [
-                ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
-            ],
-        ]
+            ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"): {
+                (("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
+                 ("numpy", "1.0.0", "https://pypi.org/simple")),
+                (("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
+                 ("numpy", "2.0.0", "https://pypi.org/simple")),
+
+            }
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
@@ -267,27 +264,24 @@ class TestLimitLatestVersions(AdviserTestCase):
         limit_latest_versions.update_parameters({"limit_latest_versions": 2})
         limit_latest_versions.run(step_context)
 
-        pairs = list(sorted(
-            step_context.dependency_graph_adaptation.to_scored_package_tuple_pairs(),
-            key=operator.itemgetter(0)
-        ))
+        pairs = step_context.dependency_graph_adaptation.to_scored_package_tuple_pairs()
 
-        assert pairs == [
+        assert set(pairs) == {
             (0.0, (None, ('tensorflow', '1.9.0', 'https://thoth-station.ninja/simple'))),
+            (0.0, (None, ('tensorflow', '2.0.0', 'https://thoth-station.ninja/simple'))),
             (0.0, (('tensorflow', '1.9.0', 'https://thoth-station.ninja/simple'),
                    ('numpy', '1.0.0', 'https://pypi.org/simple'))),
             (0.0, (('tensorflow', '1.9.0', 'https://thoth-station.ninja/simple'),
                    ('numpy', '2.0.0', 'https://pypi.org/simple'))),
-            (0.0, (None, ('tensorflow', '2.0.0', 'https://thoth-station.ninja/simple'))),
+            (0.0, (('tensorflow', '2.0.0', 'https://thoth-station.ninja/simple'),
+                   ('numpy', '2.0.0', 'https://pypi.org/simple'))),
             (0.0, (('tensorflow', '2.0.0', 'https://thoth-station.ninja/simple'),
                    ('numpy', '1.0.0', 'https://pypi.org/simple'))),
-            (0.0, (('tensorflow', '2.0.0', 'https://thoth-station.ninja/simple'),
-                   ('numpy', '2.0.0', 'https://pypi.org/simple')))
-        ]
+        }
 
-        assert list(
+        assert set(
             pv.to_tuple() for pv in step_context.iter_direct_dependencies()
-        ) == [
+        ) == {
             ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
             ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
-        ]
+        }

--- a/tests/python/pipeline/steps/test_observation_reduction.py
+++ b/tests/python/pipeline/steps/test_observation_reduction.py
@@ -30,39 +30,37 @@ class TestObservationReduction(AdviserTestCase):
 
     def test_no_observation_latest(self):
         """Test that we always end up with the latest version possible if no observations are found."""
-        direct_dependencies = [
-            PackageVersion(
+        source = Source("https://pypi.org/simple")
+        direct_dependencies = {
+            ("tensorflow", "2.0.0", source.url): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
                 index=Source("https://pypi.org/simple"),
                 develop=False,
             ),
-            PackageVersion(
+            ("tensorflow", "1.9.0", source.url): PackageVersion(
                 name="tensorflow",
                 version="==1.9.0",
                 index=Source("https://pypi.org/simple"),
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [
-                ("tensorflow", "1.9.0", "https://pypi.org/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("tensorflow", "1.9.0", "https://pypi.org/simple"): [
+                (("tensorflow", "1.9.0", "https://pypi.org/simple"),
+                 ("numpy", "1.0.0", "https://pypi.org/simple")),
+                (("tensorflow", "1.9.0", "https://pypi.org/simple"),
+                ("numpy", "2.0.0", "https://pypi.org/simple")),
             ],
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): [
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "2.0.0", "https://pypi.org/simple")),
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "1.0.0", "https://pypi.org/simple")),
             ],
-            [
-                ("tensorflow", "1.9.0", "https://pypi.org/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
-            ],
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
-            ],
-        ]
+        }
+
         step_context = StepContext.from_paths(direct_dependencies, paths=paths)
 
         observation_reduction = ObservationReduction(
@@ -82,27 +80,28 @@ class TestObservationReduction(AdviserTestCase):
 
     def test_cyclic(self):
         """Test cyclic dependencies - test we actually break cycles."""
-        direct_dependencies = [
-            PackageVersion(
+        direct_dependencies = {
+            ("a", "2.0.0", "https://pypi.org/simple"): PackageVersion(
                 name="a",
                 version="==2.0.0",
                 index=Source("https://pypi.org/simple"),
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [
-                ("a", "2.0.0", "https://pypi.org/simple"),
-                ("b", "2.0.0", "https://pypi.org/simple"),
-                ("c", "2.0.0", "https://pypi.org/simple"),
-                ("b", "2.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("a", "2.0.0", "https://pypi.org/simple"): [
+                (("a", "2.0.0", "https://pypi.org/simple"),
+                 ("b", "2.0.0", "https://pypi.org/simple")),
+                (("b", "2.0.0", "https://pypi.org/simple"),
+                 ("c", "2.0.0", "https://pypi.org/simple")),
+                (("c", "2.0.0", "https://pypi.org/simple"),
+                 ("b", "2.0.0", "https://pypi.org/simple")),
+                (("a", "2.0.0", "https://pypi.org/simple"),
+                 ("b", "1.0.0", "https://pypi.org/simple")),
             ],
-            [
-                ("a", "2.0.0", "https://pypi.org/simple"),
-                ("b", "1.0.0", "https://pypi.org/simple"),
-            ],
-        ]
+        }
+
         step_context = StepContext.from_paths(direct_dependencies, paths=paths)
 
         observation_reduction = ObservationReduction(
@@ -125,39 +124,36 @@ class TestObservationReduction(AdviserTestCase):
 
     def test_one_observation(self):
         """Test one observation and subsequent correct reduction."""
-        direct_dependencies = [
-            PackageVersion(
+        source = Source("https://pypi.org/simple")
+        direct_dependencies = {
+            ("a", "2.0.0", source.url): PackageVersion(
                 name="a",
                 version="==2.0.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-            PackageVersion(
+            ("a", "1.0.0", source.url): PackageVersion(
                 name="a",
                 version="==1.0.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [
-                ("a", "2.0.0", "https://pypi.org/simple"),
-                ("b", "2.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("a", "2.0.0", "https://pypi.org/simple"): [
+                (("a", "2.0.0", "https://pypi.org/simple"),
+                 ("b", "2.0.0", "https://pypi.org/simple")),
+                (("a", "2.0.0", "https://pypi.org/simple"),
+                 ("b", "1.0.0", "https://pypi.org/simple")),
             ],
-            [
-                ("a", "2.0.0", "https://pypi.org/simple"),
-                ("b", "1.0.0", "https://pypi.org/simple"),
+            ("a", "1.0.0", "https://pypi.org/simple"): [
+                (("a", "1.0.0", "https://pypi.org/simple"),
+                 ("b", "2.0.0", "https://pypi.org/simple")),
+                (("a", "1.0.0", "https://pypi.org/simple"),
+                 ("b", "1.0.0", "https://pypi.org/simple")),
             ],
-            [
-                ("a", "1.0.0", "https://pypi.org/simple"),
-                ("b", "2.0.0", "https://pypi.org/simple"),
-            ],
-            [
-                ("a", "1.0.0", "https://pypi.org/simple"),
-                ("b", "1.0.0", "https://pypi.org/simple"),
-            ],
-        ]
+        }
         step_context = StepContext.from_paths(direct_dependencies, paths=paths)
 
         step_context.score_package_tuple(("a", "1.0.0", "https://pypi.org/simple"), 2.0)
@@ -178,29 +174,30 @@ class TestObservationReduction(AdviserTestCase):
 
     def test_multiple_observation(self):
         """Test adjustment based on multiple observations.."""
-        direct_dependencies = [
-            PackageVersion(
+        source = Source("https://pypi.org/simple")
+        direct_dependencies = {
+            ("a", "2.0.0", source.url): PackageVersion(
                 name="a",
                 version="==2.0.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-            PackageVersion(
+            ("a", "3.0.0", source.url): PackageVersion(
                 name="a",
                 version="==3.0.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-            PackageVersion(
+            ("a", "1.0.0", source.url): PackageVersion(
                 name="a",
                 version="==1.0.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-        ]
+        }
 
         from itertools import product
-        paths = list(product(
+        paths_long = list(product(
             (
                 ("a", "3.0.0", "https://pypi.org/simple"),
                 ("a", "2.0.0", "https://pypi.org/simple"),
@@ -217,6 +214,14 @@ class TestObservationReduction(AdviserTestCase):
                 ("c", "1.0.0", "https://pypi.org/simple"),
             ),
         ))
+        paths = {}
+        for item in paths_long:
+            if item[0] not in paths:
+                paths[item[0]] = []
+
+            for idx in range(len(item) - 1):
+                paths[item[0]].append((item[idx], item[idx + 1]))
+
         step_context = StepContext.from_paths(direct_dependencies, paths=paths)
 
         #       Possibly resolved  |   Score     |  A    B    C   |

--- a/tests/python/pipeline/steps/test_performance_adjustment.py
+++ b/tests/python/pipeline/steps/test_performance_adjustment.py
@@ -75,34 +75,35 @@ class TestPerformanceAdjustment(AdviserTestCase):
 
     def test_direct_adjusted(self):
         """Test adjustment of direct dependencies on good perf score."""
-        direct_dependencies = [
-            PackageVersion(
+        source = Source("https://pypi.org/simple")
+        direct_dependencies = {
+            ("tensorflow", "2.0.0", source.url): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-            PackageVersion(
+            ("flask", "0.12.0", source.url): PackageVersion(
                 name="flask",
                 version="==0.12.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [("flask", "0.12.0", "https://pypi.org/simple")],
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("flask", "0.12.0", "https://pypi.org/simple"): [],
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): [
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "2.0.0", "https://pypi.org/simple")),
             ],
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
         performance_impact = {
-            ("flask", "0.12.0", "https://pypi.org/simple"): 1.0,
             ("tensorflow", "2.0.0", "https://pypi.org/simple"): 0.0,
+            ("flask", "0.12.0", "https://pypi.org/simple"): 1.0,
             ("numpy", "2.0.0", "https://pypi.org/simple"): 0,
         }
         project = self._prepare_isis_and_graph(
@@ -128,44 +129,44 @@ class TestPerformanceAdjustment(AdviserTestCase):
             (2.0, (None, ('flask', '0.12.0', 'https://pypi.org/simple')))
         ]
 
-        # Make sure Flask gets precedence in resolution.
         assert list(
             pv.to_tuple() for pv in step_context.iter_direct_dependencies()
         ) == [
-            ("flask", "0.12.0", "https://pypi.org/simple"),
             ("tensorflow", "2.0.0", "https://pypi.org/simple"),
+            ("flask", "0.12.0", "https://pypi.org/simple"),
         ]
 
     def test_transitive_adjusted(self):
         """Make sure transitive dependencies are adjusted, without affecting direct dependencies."""
-        direct_dependencies = [
-            PackageVersion(
+        source = Source("https://pypi.org/simple")
+        direct_dependencies = {
+            ("tensorflow", "2.0.0", source.url): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-            PackageVersion(
+            ("flask", "0.12.0", source.url): PackageVersion(
                 name="flask",
                 version="==0.12.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [("flask", "0.12.0", "https://pypi.org/simple")],
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("flask", "0.12.0", "https://pypi.org/simple"): [],
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): [
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "2.0.0", "https://pypi.org/simple")),
             ],
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
         performance_impact = {
-            ("flask", "0.12.0", "https://pypi.org/simple"): 1.0,
             ("tensorflow", "2.0.0", "https://pypi.org/simple"): 1.0,
+            ("flask", "0.12.0", "https://pypi.org/simple"): 1.0,
             ("numpy", "2.0.0", "https://pypi.org/simple"): 0,
         }
         project = self._prepare_isis_and_graph(
@@ -188,45 +189,46 @@ class TestPerformanceAdjustment(AdviserTestCase):
         assert pairs == [
             (0.0, (('tensorflow', '2.0.0', 'https://pypi.org/simple'),
                    ('numpy', '2.0.0', 'https://pypi.org/simple'))),
+            (3.0, (None, ('tensorflow', '2.0.0', 'https://pypi.org/simple'))),
             (3.0, (None, ('flask', '0.12.0', 'https://pypi.org/simple'))),
-            (3.0, (None, ('tensorflow', '2.0.0', 'https://pypi.org/simple')))
         ]
 
-        assert list(
+        assert set(
             pv.to_tuple() for pv in step_context.iter_direct_dependencies()
-        ) == [
+        ) == {
             ("flask", "0.12.0", "https://pypi.org/simple"),
             ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-        ]
+        }
 
     def test_adjusted(self):
         """Test adjustment of direct and indirect dependencies on good perf score."""
-        direct_dependencies = [
-            PackageVersion(
+        source = Source("https://pypi.org/simple")
+        direct_dependencies = {
+            ("tensorflow", "2.0.0", source.url): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-            PackageVersion(
+            ("flask", "0.12.0", source.url): PackageVersion(
                 name="flask",
                 version="==0.12.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [("flask", "0.12.0", "https://pypi.org/simple")],
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("flask", "0.12.0", "https://pypi.org/simple"): [],
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): [
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "2.0.0", "https://pypi.org/simple")),
             ],
-        ]
+        }
 
         performance_impact = {
-            ("flask", "0.12.0", "https://pypi.org/simple"): 0,
             ("tensorflow", "2.0.0", "https://pypi.org/simple"): 1.0,
+            ("flask", "0.12.0", "https://pypi.org/simple"): 0,
             ("numpy", "2.0.0", "https://pypi.org/simple"): 0,
         }
         project = self._prepare_isis_and_graph(
@@ -245,50 +247,51 @@ class TestPerformanceAdjustment(AdviserTestCase):
         pairs = step_context.dependency_graph_adaptation.to_scored_package_tuple_pairs()
 
         assert pairs == [
-            (0.0, (None, ('flask', '0.12.0', 'https://pypi.org/simple'))),
             (2.0, (None, ('tensorflow', '2.0.0', 'https://pypi.org/simple'))),
+            (0.0, (None, ('flask', '0.12.0', 'https://pypi.org/simple'))),
             (0.0, (('tensorflow', '2.0.0', 'https://pypi.org/simple'),
                    ('numpy', '2.0.0', 'https://pypi.org/simple')))
         ]
 
         # Make sure TF gets precedence in resolution.
-        assert list(
+        assert set(
             pv.to_tuple() for pv in step_context.iter_direct_dependencies()
-        ) == [
-            ("flask", "0.12.0", "https://pypi.org/simple"),
+        ) == {
             ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-        ]
+            ("flask", "0.12.0", "https://pypi.org/simple"),
+        }
 
     def test_no_adjusted(self):
         """Test no adjustment if there is not performance impact."""
-        direct_dependencies = [
-            PackageVersion(
+        source = Source("https://pypi.org/simple")
+        direct_dependencies = {
+            ("tensorflow", "2.0.0", source.url): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-            PackageVersion(
+            ("flask", "0.12.0", source.url): PackageVersion(
                 name="flask",
                 version="==0.12.0",
-                index=Source("https://pypi.org/simple"),
+                index=source,
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [("flask", "0.12.0", "https://pypi.org/simple")],
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("flask", "0.12.0", "https://pypi.org/simple"): [],
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): [
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "2.0.0", "https://pypi.org/simple")),
             ],
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
         performance_impact = {
-            ("flask", "0.12.0", "https://pypi.org/simple"): 0,
             ("tensorflow", "2.0.0", "https://pypi.org/simple"): 0.0,
+            ("flask", "0.12.0", "https://pypi.org/simple"): 0,
             ("numpy", "2.0.0", "https://pypi.org/simple"): 0,
         }
         project = self._prepare_isis_and_graph(
@@ -303,15 +306,15 @@ class TestPerformanceAdjustment(AdviserTestCase):
         performance_adjustment.run(step_context)
 
         assert step_context.dependency_graph_adaptation.to_scored_package_tuple_pairs() == [
-            (0.0, (None, ('flask', '0.12.0', 'https://pypi.org/simple'))),
             (0.0, (None, ('tensorflow', '2.0.0', 'https://pypi.org/simple'))),
+            (0.0, (None, ('flask', '0.12.0', 'https://pypi.org/simple'))),
             (0.0, (('tensorflow', '2.0.0', 'https://pypi.org/simple'),
                    ('numpy', '2.0.0', 'https://pypi.org/simple')))
         ]
 
-        assert list(
+        assert set(
             pv.to_tuple() for pv in step_context.iter_direct_dependencies()
-        ) == [
+        ) == {
             ("flask", "0.12.0", "https://pypi.org/simple"),
             ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-        ]
+        }

--- a/tests/python/pipeline/steps/test_restrict_indexes.py
+++ b/tests/python/pipeline/steps/test_restrict_indexes.py
@@ -51,31 +51,29 @@ tensorflow = "==2.0.0"
 
     def test_remove_direct(self):
         """Test removal of direct dependencies which do not correspond to restricted indexes."""
-        direct_dependencies = [
-            PackageVersion(
+        direct_dependencies = {
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
                 index=Source("https://pypi.org/simple"),
                 develop=False,
             ),
-            PackageVersion(
+            ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
                 index=Source("https://thoth-station.ninja/simple"),
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): [
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "1.0.0", "https://pypi.org/simple")),
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "2.0.0", "https://pypi.org/simple")),
             ],
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "2.0.0", "https://pypi.org/simple"),
-            ],
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
@@ -103,31 +101,23 @@ tensorflow = "==2.0.0"
 
     def test_remove_transitive(self):
         """Test removal of indirect dependencies which do not correspond to restricted indexes."""
-        direct_dependencies = [
-            PackageVersion(
+        direct_dependencies = {
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
                 index=Source("https://pypi.org/simple"),
                 develop=False,
             ),
-            PackageVersion(
-                name="tensorflow",
-                version="==1.9.0",
-                index=Source("https://pypi.org/simple"),
-                develop=False,
-            ),
-        ]
+        }
 
-        paths = [
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): [
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "1.0.0", "https://pypi.org/simple")),
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "2.0.0", "https://thoth-station.ninja/simple")),
             ],
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "2.0.0", "https://thoth-station.ninja/simple"),
-            ],
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
@@ -143,47 +133,45 @@ tensorflow = "==2.0.0"
             (0.0, (None, ('tensorflow', '2.0.0', 'https://pypi.org/simple'))),
             (0.0, (('tensorflow', '2.0.0', 'https://pypi.org/simple'),
                    ('numpy', '1.0.0', 'https://pypi.org/simple'))),
-            (0.0, (None, ('tensorflow', '1.9.0', 'https://pypi.org/simple')))
         ]
         assert (
-            len(list(step_context.iter_direct_dependencies())) == 2
+            len(list(step_context.iter_direct_dependencies())) == 1
         ), "Wrong number of direct dependencies"
+        assert list(step_context.iter_direct_dependencies_tuple()) == [
+            ('tensorflow', '2.0.0', 'https://pypi.org/simple')
+        ]
 
     def test_remove2(self):
         """Test removal of both, direct and transitive dependencies in one run."""
-        direct_dependencies = [
-            PackageVersion(
+        direct_dependencies = {
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
                 index=Source("https://pypi.org/simple"),
                 develop=False,
             ),
-            PackageVersion(
+            ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"): PackageVersion(
                 name="tensorflow",
                 version="==1.9.0",
                 index=Source("https://thoth-station.ninja/simple"),
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): [
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "1.0.0", "https://pypi.org/simple")),
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "2.0.0", "https://thoth-station.ninja/simple")),
             ],
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "2.0.0", "https://thoth-station.ninja/simple"),
+            ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"): [
+                (("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
+                 ("numpy", "2.0.0", "https://thoth-station.ninja/simple")),
+                (("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
+                 ("numpy", "1.0.0", "https://pypi.org/simple")),
             ],
-            [
-                ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "2.0.0", "https://thoth-station.ninja/simple"),
-            ],
-            [
-                ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"),
-                ("numpy", "1.0.0", "https://pypi.org/simple"),
-            ],
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
@@ -206,25 +194,23 @@ tensorflow = "==2.0.0"
 
     def test_remove_all_transitive_error(self):
         """Test raising of an error if all the transitive deps of a type were removed."""
-        direct_dependencies = [
-            PackageVersion(
+        direct_dependencies = {
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
                 index=Source("https://pypi.org/simple"),
                 develop=False,
             )
-        ]
+        }
 
-        paths = [
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "1.0.0", "https://thoth-station.ninja/simple"),
+        paths = {
+            ("tensorflow", "2.0.0", "https://pypi.org/simple"): [
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "1.0.0", "https://thoth-station.ninja/simple")),
+                (("tensorflow", "2.0.0", "https://pypi.org/simple"),
+                 ("numpy", "2.0.0", "https://thoth-station.ninja/simple")),
             ],
-            [
-                ("tensorflow", "2.0.0", "https://pypi.org/simple"),
-                ("numpy", "2.0.0", "https://thoth-station.ninja/simple"),
-            ],
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
@@ -240,27 +226,27 @@ tensorflow = "==2.0.0"
 
     def test_remove_all_direct_error(self):
         """Test raising an error if all the direct deps of a type were removed."""
-        direct_dependencies = [
-            PackageVersion(
+        direct_dependencies = {
+            ("tensorflow", "1.9.0", "https://thoth-station.ninja/simple"): PackageVersion(
                 name="tensorflow",
                 version="==1.9.0",
                 index=Source("https://thoth-station.ninja/simple"),
                 develop=False,
             ),
-            PackageVersion(
+            ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"): PackageVersion(
                 name="tensorflow",
                 version="==2.0.0",
                 index=Source("https://thoth-station.ninja/simple"),
                 develop=False,
             ),
-        ]
+        }
 
-        paths = [
-            [
-                ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
-                ("absl-py", "1.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"): [
+                (("tensorflow", "2.0.0", "https://thoth-station.ninja/simple"),
+                 ("absl-py", "1.0.0", "https://pypi.org/simple")),
             ]
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 

--- a/tests/python/pipeline/steps/test_toolchain.py
+++ b/tests/python/pipeline/steps/test_toolchain.py
@@ -37,32 +37,27 @@ class TestCutToolchain(AdviserTestCase):
 
         In other words - always keep latest toolchain.
         """
-        direct_dependencies = [
-            PackageVersion(
+        direct_dependencies = {
+            ("flask", "0.12", "https://pypi.org/simple"): PackageVersion(
                 name="flask",
                 version="==0.12",
                 index=Source("https://pypi.org/simple"),
                 develop=False,
             )
-        ]
+        }
 
-        paths = [
-            [
-                ("flask", "0.12", "https://pypi.org/simple"),
-                ("werkzeug", "0.15.1", "https://pypi.org/simple"),
-                ("wheel", "1.12.0", "https://pypi.org/simple"),
+        paths = {
+            ("flask", "0.12", "https://pypi.org/simple"): [
+                (("flask", "0.12", "https://pypi.org/simple"),
+                 ("werkzeug", "0.15.1", "https://pypi.org/simple")),
+                (("werkzeug", "0.15.1", "https://pypi.org/simple"),
+                 ("wheel", "1.12.0", "https://pypi.org/simple")),
+                (("werkzeug", "0.15.1", "https://pypi.org/simple"),
+                 ("six", "1.12.1", "https://pypi.org/simple")),
+                (("werkzeug", "0.15.1", "https://pypi.org/simple"),
+                 ("wheel", "1.12.1", "https://pypi.org/simple")),
             ],
-            [
-                ("flask", "0.12", "https://pypi.org/simple"),
-                ("werkzeug", "0.15.1", "https://pypi.org/simple"),
-                ("six", "1.12.1", "https://pypi.org/simple"),
-            ],
-            [
-                ("flask", "0.12", "https://pypi.org/simple"),
-                ("werkzeug", "0.15.1", "https://pypi.org/simple"),
-                ("wheel", "1.12.1", "https://pypi.org/simple"),
-            ],
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
@@ -86,41 +81,31 @@ class TestCutToolchain(AdviserTestCase):
 
     def test_remove_multi(self):
         """Check all types of "toolchain" packages get removed."""
-        direct_dependencies = [
-            PackageVersion(
+        direct_dependencies = {
+            ("goblinoid", "1.0.0", "https://pypi.org/simple"): PackageVersion(
                 name="goblinoid",
                 version="==1.0.0",
                 index=Source("https://pypi.org/simple"),
                 develop=False,
             )
-        ]
+        }
 
-        paths = [
-            [
-                ("goblinoid", "1.0.0", "https://pypi.org/simple"),
-                ("wheel", "1.0.0", "https://pypi.org/simple"),
-            ],
-            [
-                ("goblinoid", "1.0.0", "https://pypi.org/simple"),
-                ("wheel", "2.0.0", "https://pypi.org/simple"),
-            ],
-            [
-                ("goblinoid", "1.0.0", "https://pypi.org/simple"),
-                ("setuptools", "1.0.0", "https://pypi.org/simple"),
-            ],
-            [
-                ("goblinoid", "1.0.0", "https://pypi.org/simple"),
-                ("setuptools", "2.0.0", "https://pypi.org/simple"),
-            ],
-            [
-                ("goblinoid", "1.0.0", "https://pypi.org/simple"),
-                ("pip", "1.0.0", "https://pypi.org/simple"),
-            ],
-            [
-                ("goblinoid", "1.0.0", "https://pypi.org/simple"),
-                ("pip", "2.0.0", "https://pypi.org/simple"),
-            ],
-        ]
+        paths = {
+            ("goblinoid", "1.0.0", "https://pypi.org/simple"): [
+                (("goblinoid", "1.0.0", "https://pypi.org/simple"),
+                 ("wheel", "1.0.0", "https://pypi.org/simple")),
+                (("goblinoid", "1.0.0", "https://pypi.org/simple"),
+                 ("wheel", "2.0.0", "https://pypi.org/simple")),
+                (("goblinoid", "1.0.0", "https://pypi.org/simple"),
+                 ("setuptools", "1.0.0", "https://pypi.org/simple")),
+                (("goblinoid", "1.0.0", "https://pypi.org/simple"),
+                 ("setuptools", "2.0.0", "https://pypi.org/simple")),
+                (("goblinoid", "1.0.0", "https://pypi.org/simple"),
+                 ("pip", "1.0.0", "https://pypi.org/simple")),
+                (("goblinoid", "1.0.0", "https://pypi.org/simple"),
+                 ("pip", "2.0.0", "https://pypi.org/simple")),
+            ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 
@@ -143,21 +128,21 @@ class TestCutToolchain(AdviserTestCase):
 
     def test_no_remove(self):
         """Make sure packages which are not toolchain do not get removed."""
-        direct_dependencies = [
-            PackageVersion(
+        direct_dependencies = {
+            ("goblinoid", "1.0.0", "https://pypi.org/simple"): PackageVersion(
                 name="goblinoid",
                 version="==1.0.0",
                 index=Source("https://pypi.org/simple"),
                 develop=False,
             )
-        ]
+        }
 
-        paths = [
-            [
-                ("goblinoid", "1.0.0", "https://pypi.org/simple"),
-                ("foo", "1.0.0", "https://pypi.org/simple"),
+        paths = {
+            ("goblinoid", "1.0.0", "https://pypi.org/simple"): [
+                (("goblinoid", "1.0.0", "https://pypi.org/simple"),
+                 ("foo", "1.0.0", "https://pypi.org/simple")),
             ]
-        ]
+        }
 
         step_context = StepContext.from_paths(direct_dependencies, paths)
 

--- a/thoth/adviser/python/dependency_graph/adaptation/graph.py
+++ b/thoth/adviser/python/dependency_graph/adaptation/graph.py
@@ -122,11 +122,8 @@ class DependencyGraph:
             if package_node1.package_tuple[0] not in package_node2.incoming_edges:
                 package_node2.incoming_edges[package_node1.package_tuple[0]] = {}
 
-            if (
-                    package_node1.package_tuple
-                    not in package_node2.incoming_edges[package_node1.package_tuple[0]]
-               ):
-                    package_node2.incoming_edges[package_node1.package_tuple[0]][package_node1.package_tuple] = edge
+            if package_node1.package_tuple not in package_node2.incoming_edges[package_node1.package_tuple[0]]:
+                package_node2.incoming_edges[package_node1.package_tuple[0]][package_node1.package_tuple] = edge
 
         return cls(
             packages_map=packages_map,

--- a/thoth/adviser/python/dependency_graph/adaptation/graph.py
+++ b/thoth/adviser/python/dependency_graph/adaptation/graph.py
@@ -71,6 +71,9 @@ class DependencyGraph:
         edges_map = {}
         direct_dependency_map = {}
 
+        if not direct_dependencies:
+            raise ValueError("No direct dependencies specified")
+
         for direct_dependency in direct_dependencies:
             direct_dependency_node = packages_map.get(direct_dependency)
             if direct_dependency_node is None:
@@ -86,6 +89,8 @@ class DependencyGraph:
             if not edge:
                 edge = Edge(source=None, target=direct_dependency_node)
                 edges_map[edge.get_edge_key()] = edge
+                direct_dependency_node.incoming_edges[None] = {}
+                direct_dependency_node.incoming_edges[None][None] = edge
 
         for path in paths or []:
             if len(path) != 2:

--- a/thoth/adviser/python/dependency_graph/adaptation/graph.py
+++ b/thoth/adviser/python/dependency_graph/adaptation/graph.py
@@ -61,25 +61,26 @@ class DependencyGraph:
     )
 
     @classmethod
-    def from_paths(cls, paths: List[List[Tuple[str, str, str]]]) -> "DependencyGraph":
+    def from_paths(cls, direct_dependencies: List[Tuple[str, str, str]], paths: List[List[Tuple[str, str, str]]]) -> "DependencyGraph":
         """Construct dependency graph from paths."""
         packages_map = {}
         edges_map = {}
         direct_dependency_map = {}
 
+        for direct_dependency in direct_dependencies:
+            direct_dependency_node = packages_map.get(direct_dependency)
+            if direct_dependency_node is None:
+                direct_dependency_node = Node(direct_dependency)
+                packages_map[direct_dependency_node.package_tuple] = direct_dependency
+
+            if direct_dependency_node.package_tuple not in direct_dependency_map:
+                direct_dependency_map[
+                    direct_dependency_node.package_tuple
+                ] = direct_dependency_node
+
         for path in paths or []:
             if not path:
                 raise ValueError("Empty path supplied")
-
-            direct_dependency = packages_map.get(path[0])
-            if direct_dependency is None:
-                direct_dependency = Node(path[0])
-                packages_map[direct_dependency.package_tuple] = direct_dependency
-
-            if direct_dependency.package_tuple not in direct_dependency_map:
-                direct_dependency_map[
-                    direct_dependency.package_tuple
-                ] = direct_dependency
 
             previous = None
             for package_tuple in path:

--- a/thoth/adviser/python/dependency_graph/adaptation/graph.py
+++ b/thoth/adviser/python/dependency_graph/adaptation/graph.py
@@ -61,7 +61,11 @@ class DependencyGraph:
     )
 
     @classmethod
-    def from_paths(cls, direct_dependencies: List[Tuple[str, str, str]], paths: List[List[Tuple[str, str, str]]]) -> "DependencyGraph":
+    def from_paths(
+        cls,
+        direct_dependencies: List[Tuple[str, str, str]],
+        paths: List[Tuple[Tuple[str, str, str], Tuple[str, str, str]]]
+    ) -> "DependencyGraph":
         """Construct dependency graph from paths."""
         packages_map = {}
         edges_map = {}
@@ -71,64 +75,60 @@ class DependencyGraph:
             direct_dependency_node = packages_map.get(direct_dependency)
             if direct_dependency_node is None:
                 direct_dependency_node = Node(direct_dependency)
-                packages_map[direct_dependency_node.package_tuple] = direct_dependency
+                packages_map[direct_dependency_node.package_tuple] = direct_dependency_node
 
             if direct_dependency_node.package_tuple not in direct_dependency_map:
                 direct_dependency_map[
                     direct_dependency_node.package_tuple
                 ] = direct_dependency_node
 
+            edge = edges_map.get((None, direct_dependency_node.package_tuple))
+            if not edge:
+                edge = Edge(source=None, target=direct_dependency_node)
+                edges_map[edge.get_edge_key()] = edge
+
         for path in paths or []:
-            if not path:
-                raise ValueError("Empty path supplied")
+            if len(path) != 2:
+                raise ValueError("Path does not carry source and destination")
 
-            previous = None
-            for package_tuple in path:
-                package_node = packages_map.get(package_tuple)
+            package_node1 = packages_map.get(path[0])
+            if not package_node1:
+                package_node1 = Node(path[0])
+                packages_map[package_node1.package_tuple] = package_node1
 
-                if not package_node:
-                    package_node = Node(package_tuple)
-                    packages_map[package_tuple] = package_node
+            package_node2 = packages_map.get(path[1])
+            if not package_node2:
+                package_node2 = Node(path[1])
+                packages_map[package_node2.package_tuple] = package_node2
 
-                previous_package_tuple = (
-                    previous.package_tuple if previous is not None else None
-                )
-                previous_package_name = (
-                    previous_package_tuple[0] if previous_package_tuple else None
-                )
+            edge = edges_map.get(
+                (package_node1.package_tuple, package_node2.package_tuple)
+            )
+            if edge is None:
+                edge = Edge(source=package_node1, target=package_node2)
+                edges_map[edge.get_edge_key()] = edge
 
-                edge = edges_map.get(
-                    (previous_package_tuple, package_node.package_tuple)
-                )
-                if edge is None:
-                    edge = Edge(source=previous, target=package_node)
-                    edges_map[edge.get_edge_key()] = edge
+            if package_node2.package_tuple[0] not in package_node1.outgoing_edges:
+                package_node1.outgoing_edges[package_node2.package_tuple[0]] = {}
 
-                if previous:
-                    if package_node.package_tuple[0] not in previous.outgoing_edges:
-                        previous.outgoing_edges[package_node.package_tuple[0]] = {}
-
-                    if (
-                        package_node.package_tuple
-                        not in previous.outgoing_edges[package_node.package_tuple[0]]
-                    ):
-                        previous.outgoing_edges[package_node.package_tuple[0]][
-                            package_node.package_tuple
-                        ] = edge
-
-                if previous_package_name not in package_node.incoming_edges:
-                    package_node.incoming_edges[previous_package_name] = {}
-
-                if (
-                    edge.get_edge_key()
-                    not in package_node.incoming_edges[previous_package_name]
-                ):
-                    package_node.incoming_edges[previous_package_name][
-                        previous_package_tuple
+            if (
+                package_node2.package_tuple
+                not in package_node1.outgoing_edges[package_node2.package_tuple[0]]
+            ):
+                package_node1.outgoing_edges[package_node2.package_tuple[0]][
+                        package_node2.package_tuple
                     ] = edge
 
-                previous = package_node
+            if package_node1.package_tuple[0] not in package_node2.incoming_edges:
+                package_node2.incoming_edges[package_node1.package_tuple[0]] = {}
 
+            if (
+                    package_node1.package_tuple
+                    not in package_node2.incoming_edges[package_node1.package_tuple[0]]
+               ):
+                    package_node2.incoming_edges[package_node1.package_tuple[0]][package_node1.package_tuple] = edge
+
+        _LOGGER.debug("Graph adaptation has been created")
         return cls(
             packages_map=packages_map,
             edges_map=edges_map,

--- a/thoth/adviser/python/dependency_graph/adaptation/graph.py
+++ b/thoth/adviser/python/dependency_graph/adaptation/graph.py
@@ -128,7 +128,6 @@ class DependencyGraph:
                ):
                     package_node2.incoming_edges[package_node1.package_tuple[0]][package_node1.package_tuple] = edge
 
-        _LOGGER.debug("Graph adaptation has been created")
         return cls(
             packages_map=packages_map,
             edges_map=edges_map,

--- a/thoth/adviser/python/pipeline/step_context.py
+++ b/thoth/adviser/python/pipeline/step_context.py
@@ -78,7 +78,10 @@ class StepContext(ContextBase):
         )
         return cls(
             packages=packages,
-            dependency_graph_adaptation=DependencyGraphAdaptation.from_paths(paths),
+            dependency_graph_adaptation=DependencyGraphAdaptation.from_paths(
+                direct_dependencies=[d.to_tuple for d in direct_dependencies],
+                paths=paths
+            ),
         )
 
     @property

--- a/thoth/adviser/python/pipeline/step_context.py
+++ b/thoth/adviser/python/pipeline/step_context.py
@@ -21,7 +21,6 @@ from typing import Dict
 from typing import Generator
 from typing import List
 from typing import Tuple
-from typing import Set
 from typing import Callable
 from itertools import chain
 import logging

--- a/thoth/adviser/python/pipeline/step_context.py
+++ b/thoth/adviser/python/pipeline/step_context.py
@@ -21,6 +21,7 @@ from typing import Dict
 from typing import Generator
 from typing import List
 from typing import Tuple
+from typing import Set
 from typing import Callable
 from itertools import chain
 import logging
@@ -49,29 +50,29 @@ class StepContext(ContextBase):
     @classmethod
     def from_paths(
         cls,
-        direct_dependencies: List[PackageVersion],
-        paths: List[List[Tuple[str, str, str]]],
+        direct_dependencies: Dict[Tuple[str, str, str], PackageVersion],
+        paths: Dict[Tuple[str, str, str], List[Tuple[Tuple[str, str, str], Tuple[str, str, str]]]],
     ) -> "StepContext":
         """Instantiate step context from paths."""
-        _LOGGER.debug("Preparing for instantiating step context")
-        packages = {p.to_tuple(): p for p in direct_dependencies}
-        for path in paths:
-            develop = packages[path[0]].develop
-            for package_tuple in path:
-                if package_tuple in packages:
-                    continue
+        packages = dict(direct_dependencies)
+        for direct_dependency_tuple, dependency_paths in paths.items():
+            for package_tuples in dependency_paths:
+                for package_tuple in package_tuples:
+                    if package_tuple in packages:
+                        continue
 
-                package_version = PackageVersion(
-                    name=package_tuple[0],
-                    version="==" + package_tuple[1],
-                    develop=develop,
-                    index=Source(package_tuple[2]),
-                )
-                packages[package_tuple] = package_version
+                    package_version = PackageVersion(
+                        name=package_tuple[0],
+                        version="==" + package_tuple[1],
+                        develop=direct_dependencies[direct_dependency_tuple].develop,
+                        index=Source(package_tuple[2]),
+                    )
+                    packages[package_tuple] = package_version
 
-        # Explicitly assign paths to direct dependencies to have them present even if they do not have any dependency.
-        for direct_dependency in direct_dependencies:
-            paths.append([direct_dependency.to_tuple()])
+        path_tuples = []
+        for dependency_paths in paths.values():
+            for path in dependency_paths:
+                path_tuples.append(path)
 
         _LOGGER.info(
             "Instantiating step context and constructing dependency graph adaptation"
@@ -79,8 +80,8 @@ class StepContext(ContextBase):
         return cls(
             packages=packages,
             dependency_graph_adaptation=DependencyGraphAdaptation.from_paths(
-                direct_dependencies=[d.to_tuple for d in direct_dependencies],
-                paths=paths
+                direct_dependencies=direct_dependencies.keys(),
+                paths=path_tuples,
             ),
         )
 

--- a/thoth/adviser/python/pipeline/step_context.py
+++ b/thoth/adviser/python/pipeline/step_context.py
@@ -74,6 +74,10 @@ class StepContext(ContextBase):
             for path in dependency_paths:
                 path_tuples.append(path)
 
+        _LOGGER.debug(
+            "Total number of packages considered including all transitive dependencies: %d",
+            len(packages)
+        )
         _LOGGER.info(
             "Instantiating step context and constructing dependency graph adaptation"
         )


### PR DESCRIPTION
This pull request includes multiple changes:

* uses a new way of retrieving data from graph database - according to https://github.com/thoth-station/storages/pull/838
* adjusted testsuite use
* together with https://github.com/thoth-station/storages/pull/838 the memory consumption for recommending a tensorflow stack dropped to something like ~200-250Mi (any TF stack including our AICEoE builds)