### PR TITLE
Fix handling of additional pytest arguments in setup.py test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,17 @@ def read(fname):
 
 
 class Test(TestCommand):
+    """Introduce test command to run testsuite using pytest."""
+
+    _IMPLICIT_PYTEST_ARGS = ['tests/', '--timeout=2', '--cov=./thoth', '--capture=no', '--verbose', '-l', '-s', '-vv']
+
     user_options = [
         ('pytest-args=', 'a', "Arguments to pass into py.test")
     ]
 
     def initialize_options(self):
         super().initialize_options()
-        self.pytest_args = ['tests/', '--timeout=2', '--cov=./thoth', '--capture=no', '--verbose', '-l', '-s', '-vv']
+        self.pytest_args = None
 
     def finalize_options(self):
         super().finalize_options()
@@ -41,7 +45,13 @@ class Test(TestCommand):
 
     def run_tests(self):
         import pytest
-        sys.exit(pytest.main(self.pytest_args))
+        passed_args = list(self._IMPLICIT_PYTEST_ARGS)
+
+        if self.pytest_args:
+            self.pytest_args = [arg for arg in self.pytest_args.split() if arg]
+            passed_args.extend(self.pytest_args)
+
+        sys.exit(pytest.main(passed_args))
 
 
 VERSION = get_version()


### PR DESCRIPTION
... so that it's possible to run `pytest` using:

```
pipenv run python3 setup.py test -a "-x -k foo"
```

I see this issue in other packages, we need to update them as well.