### PR TITLE
Turn error into warning

### DIFF
--- a/thoth/adviser/python/pipeline/pipeline.py
+++ b/thoth/adviser/python/pipeline/pipeline.py
@@ -147,7 +147,7 @@ class Pipeline:
                 if runtime_environment.python_version:
                     error_msg += f" for Python in version {runtime_environment.python_version!r}"
 
-                _LOGGER.error(error_msg)
+                _LOGGER.warning(error_msg)
                 continue
 
             direct_dependencies.extend(package_versions)


### PR DESCRIPTION
Errors are reported to sentry so let's turn the error reported into a warning,
we will fail adviser anyway - users get notification on what caused the
failure.