### PR TITLE
Add Sentry DSN to build of adviser-cached

### DIFF
--- a/openshift/buildConfig-cached-template.yaml
+++ b/openshift/buildConfig-cached-template.yaml
@@ -65,6 +65,11 @@ objects:
             kind: ImageStreamTag
             name: adviser:latest
           env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: thoth
+                  key: sentry-dsn
             - name: THOTH_DEPLOYMENT_NAME
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
... so that we get reports to sentry if anything goes wrong during cache build