### PR TITLE
use postgresql hostname from thoth configmap

### DIFF
--- a/openshift/buildConfig-cached-template.yaml
+++ b/openshift/buildConfig-cached-template.yaml
@@ -114,7 +114,10 @@ objects:
                   name: thoth
                   key: ceph-secret-key
             - name: KNOWLEDGE_GRAPH_HOST
-              value: postgresql
+              valueFrom:
+                configMapKeyRef:
+                  key: postgresql-host
+                  name: thoth
             - name: KNOWLEDGE_GRAPH_PORT
               value: "5432"
             - name: KNOWLEDGE_GRAPH_SSL_DISABLED

--- a/openshift/job-adviser-template.yaml
+++ b/openshift/job-adviser-template.yaml
@@ -177,7 +177,10 @@ objects:
                       name: thoth
                       key: sentry-dsn
                 - name: KNOWLEDGE_GRAPH_HOST
-                  value: postgresql
+                  valueFrom:
+                    configMapKeyRef:
+                      key: postgresql-host
+                      name: thoth
                 - name: KNOWLEDGE_GRAPH_PORT
                   value: "5432"
                 - name: KNOWLEDGE_GRAPH_SSL_DISABLED

--- a/openshift/job-dependencyMonkey-template.yaml
+++ b/openshift/job-dependencyMonkey-template.yaml
@@ -167,7 +167,10 @@ objects:
                       name: thoth
                       key: sentry-dsn
                 - name: KNOWLEDGE_GRAPH_HOST
-                  value: postgresql
+                  valueFrom:
+                    configMapKeyRef:
+                      key: postgresql-host
+                      name: thoth
                 - name: KNOWLEDGE_GRAPH_PORT
                   value: "5432"
                 - name: KNOWLEDGE_GRAPH_SSL_DISABLED

--- a/openshift/job-provenanceChecker-template.yaml
+++ b/openshift/job-provenanceChecker-template.yaml
@@ -125,7 +125,10 @@ objects:
                       name: thoth
                       key: sentry-dsn
                 - name: KNOWLEDGE_GRAPH_HOST
-                  value: postgresql
+                  valueFrom:
+                    configMapKeyRef:
+                      key: postgresql-host
+                      name: thoth
                 - name: KNOWLEDGE_GRAPH_PORT
                   value: "5432"
                 - name: KNOWLEDGE_GRAPH_SSL_DISABLED


### PR DESCRIPTION
use postgresql hostname from thoth configmap
depends-on: https://github.com/thoth-station/thoth-ops/pull/97
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>