### PR TITLE
Add spaces to fix toml issues

### DIFF
--- a/tests/python/pipeline/sieves/test_prereleases.py
+++ b/tests/python/pipeline/sieves/test_prereleases.py
@@ -41,7 +41,7 @@ name = "pypi"
 [[source]]
 url = "https://tensorflow.pypi.thoth-station.ninja/index/os/fedora/30/jemalloc/simple/"
 verify_ssl = true
-name = aicoe
+name = "aicoe"
 
 [packages]
 tensorflow = "*"
@@ -59,7 +59,7 @@ name = "pypi"
 [[source]]
 url = "https://tensorflow.pypi.thoth-station.ninja/index/os/fedora/30/jemalloc/simple/"
 verify_ssl = true
-name = aicoe
+name = "aicoe"
 
 [packages]
 tensorflow = "*"


### PR DESCRIPTION
toml expects all the strings to be formatted with ", otherwise it tries to
parse it as float (?)

Fixes: #434 

Fixes issues when toml substituted contoml in #434