### PR TITLE
runtime_environment var should be dict in parameter

### DIFF
--- a/thoth/adviser/cli.py
+++ b/thoth/adviser/cli.py
@@ -383,7 +383,7 @@ def advise(
     )
 
     parameters["project"] = project.to_dict()
-
+    parameters["runtime_environment"] = parameters["project"]["runtime_environment"]
     asa = partial(
         AdaptiveSimulatedAnnealing.compute_on_project,
         project=project,


### PR DESCRIPTION
runtime_environment var should be dict in parameter
The adviser result stores the runtime_environment as str, which causes issue in sync_adviser_result in storages.
```
"result": {
    "error": true,
    "error_msg": "Unable to resolve all direct dependencies, no versions were found for packages 'daiquiri'",
    "parameters": {
      "beam_width": -1,
      "count": 1,
      "library_usage": "{\"version\": \"string\", \"report\": {}}",
      "limit": -1,
      "limit_latest_versions": -1,
      "no_pretty": false,
      "output": "http://result-api/api/v1/adviser-result",
      "plot_history": null,
      "project": {
        "requirements": { ...
        },
        "requirements_locked": { ...
        },
        "runtime_environment": {
          "cuda_version": "9.0",
          "hardware": {
            "cpu_family": null,
            "cpu_model": null
          },
          "name": "fedora:29-prod",
          "operating_system": {
            "name": null,
            "version": null
          },
          "python_version": "3.6"
        }
      },
      "recommendation_type": "STABLE",
      "requirements": "[[source]]\\nurl = \"https://pypi.python.org/simple\"\\nverify_ssl = true\\nname = \"pypi\"\\n\\n[packages]\\ndaiquiri = \"*\"\\n\\n[dev-packages]\\n",
      "requirements_format": "pipenv",
      "requirements_locked": "{ \"_meta\": { \"hash\": { \"sha256\": \"fecd8a66514e1129f796d7a45a1f5b2f7733e3ae0ead487ca63752da680ab8e4\" }, \"pipfile-spec\": 6, \"requires\": {}, \"sources\": [ { \"name\": \"pypi\", \"url\": \"https://pypi.python.org/simple\", \"verify_ssl\": true } ] }, \"default\": { \"daiquiri\": { \"hashes\": [ \"sha256:1c4942ef0d40920100162ede6024edd43734e40b8dca9b13ebaf4b52ea198457\", \"sha256:eb300dfddae43dfdb157938a854b1387298b8fb340d6ecb7b5ae867283af763e\" ], \"index\": \"pypi\", \"version\": \"==1.4.0\" } }, \"develop\": {} }",
      "runtime_environment": "{\"hardware\": {}, \"operating_system\": {}, \"python_version\": \"3.6\", \"cuda_version\": \"9.0\", \"name\": \"fedora:29-prod\", \"ipython\": {}}",
      "seed": null
    },
    "report": null
  }
```
observed the issue in adviser run with storages 0.19.15

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>