### PR TITLE
Use backtracking to run steps

### DIFF
--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -115,6 +115,23 @@ class TestBeam(AdviserTestCase):
 
         assert beam.states == [state3, state2, state1, state0]
 
+    def test_top(self) -> None:
+        """Test top element in beam."""
+        beam = Beam(width=2)
+        assert beam.width == 2
+
+        state1 = State(score=1.0)
+        beam.add_state(state1)
+        assert beam.top() is state1
+
+        state2 = State(score=2.0)
+        beam.add_state(state2)
+        assert beam.top() is state2
+
+        state3 = State(score=0.5)
+        beam.add_state(state3)
+        assert beam.top() is state2
+
     def test_add_state_order_multi(self) -> None:
         """Test adding states to beam and order during addition when score is same."""
         beam = Beam(width=2)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -216,10 +216,10 @@ class TestResolver(AdviserTestCase):
         self, resolver: Resolver, package_versions: List[PackageVersion]
     ) -> None:
         """Test running pipeline steps."""
-        state = State()
-        state.score = 0.1
-        state.add_justification([{"hello": "thoth"}])
-        state.resolved_dependencies["hexsticker"] = (
+        state1 = State()
+        state1.score = 0.1
+        state1.add_justification([{"hello": "thoth"}])
+        state1.resolved_dependencies["hexsticker"] = (
             "hexsticker",
             "1.2.0",
             "https://pypi.org/simple",
@@ -229,85 +229,95 @@ class TestResolver(AdviserTestCase):
         flexmock(steps.Step2)
 
         steps.Step1.should_receive("run").with_args(
-            state, package_versions[0]
+            state1, package_versions[0]
         ).and_return((1.0, None)).ordered()
+
         steps.Step2.should_receive("run").with_args(
-            state, package_versions[0]
+            state1, package_versions[0]
         ).and_return((0.5, [{"foo": 1}])).ordered()
 
-        steps.Step1.should_receive("run").with_args(
-            state, package_versions[1]
-        ).and_return(None).ordered()
-        steps.Step2.should_receive("run").with_args(
-            state, package_versions[1]
-        ).and_return((None, None)).ordered()
+        state2 = state1.clone()
+        state2.score += 1.0 + 0.5
+        state2.add_unresolved_dependency(package_versions[0].to_tuple())
+        state2.add_justification([{"foo": 1}])
 
         steps.Step1.should_receive("run").with_args(
-            state, package_versions[2]
+            state2, package_versions[1]
+        ).and_return((None, None)).ordered()
+
+        steps.Step2.should_receive("run").with_args(
+            state2, package_versions[1]
+        ).and_return(None).ordered()
+
+        state3 = state2.clone()
+        state3.add_unresolved_dependency(package_versions[1].to_tuple())
+
+        steps.Step1.should_receive("run").with_args(
+            state3, package_versions[2]
         ).and_return((None, [{"baz": "bar"}])).ordered()
         steps.Step2.should_receive("run").with_args(
-            state, package_versions[2]
+            state3, package_versions[2]
         ).and_return(None).ordered()
+
+        beam_state = state3.clone()
+        beam_state.add_unresolved_dependency(package_versions[2].to_tuple())
+        beam_state.add_justification([{"baz": "bar"}])
 
         resolver.pipeline.steps = [steps.Step1(), steps.Step2()]
 
         assert resolver.beam.size == 0
-        assert resolver._run_steps(state, *package_versions[:3]) is None
+        assert (
+            resolver._run_steps(state1, {pv.name: [pv] for pv in package_versions})
+            is None
+        )
         assert resolver.beam.size == 1
-        assert resolver.beam.top().to_dict() == {
-            "advised_runtime_environment": None,
-            "justification": [{"hello": "thoth"}, {"foo": 1}, {"baz": "bar"}],
-            "resolved_dependencies": state.resolved_dependencies,
-            "score": 1.6,
-            "unresolved_dependencies": OrderedDict(
-                ((p.name, p.to_tuple()) for p in package_versions)
-            ),
-        }
-
-        assert state.score == 0.1, "Score of the original state is not untouched"
-        assert state.justification == [
-            {"hello": "thoth"}
-        ], "Justification of the original score is not untouched"
+        assert resolver.beam.top() == beam_state
 
     def test_run_steps_not_acceptable(
         self, resolver: Resolver, package_versions: List[PackageVersion]
     ) -> None:
         """Test running steps when not acceptable is raised."""
-        state = State()
-        state.score = 0.1
-        state.add_justification([{"hello": "thoth"}])
-        state.resolved_dependencies["hexsticker"] = (
+        state1 = State()
+        state1.score = 0.1
+        state1.add_justification([{"hello": "thoth"}])
+        state1.resolved_dependencies["hexsticker"] = (
             "hexsticker",
             "1.2.0",
             "https://pypi.org/simple",
         )
 
-        original_state = deepcopy(state)
-
         flexmock(steps.Step1)
         flexmock(steps.Step2)
 
         steps.Step1.should_receive("run").with_args(
-            state, package_versions[0]
-        ).and_return((1.0, {"baz": "bar"})).ordered()
+            state1, package_versions[0]
+        ).and_return((1.0, [{"baz": "bar"}])).ordered()
+
         steps.Step2.should_receive("run").with_args(
-            state, package_versions[0]
+            state1, package_versions[0]
         ).and_raise(NotAcceptable).ordered()
 
         resolver.pipeline.steps = [steps.Step1(), steps.Step2()]
 
         assert resolver.beam.size == 0
-        assert resolver._run_steps(state, *package_versions[:3]) is None
+        assert (
+            resolver._run_steps(state1, {pv.name: [pv] for pv in package_versions[:3]})
+            is None
+        )
         assert resolver.beam.size == 0
-        assert original_state == state, "State is not unoutched"
 
-    @pytest.mark.parametrize("package_tuple", [
-        # Any of version or index url is different.
-        ("tensorflow", "1.9.0", "https://pypi.org/simple"),
-        ("tensorflow", "2.0.0", "https://thoth-station.ninja"),
-        ("tensorflow", "1.9.0", "https://thoth-station.ninja"),
-    ])
-    def test_run_steps_package_clash(self, package_tuple: Tuple[str, str, str], resolver: Resolver) -> None:
+    @pytest.mark.parametrize(
+        "package_tuple",
+        [
+            # Any of version or index url is different.
+            ("tensorflow", "1.9.0", "https://pypi.org/simple"),
+            ("tensorflow", "2.0.0", "https://thoth-station.ninja"),
+            ("tensorflow", "1.9.0", "https://thoth-station.ninja"),
+        ],
+    )
+    def test_run_steps_package_clash(
+        self, package_tuple: Tuple[str, str, str], resolver: Resolver
+    ) -> None:
         """Test running steps with a dependency clash."""
         pypi = Source("https://pypi.org/simple")
 
@@ -327,7 +337,16 @@ class TestResolver(AdviserTestCase):
         )
 
         assert resolver.beam.size == 0
-        assert resolver._run_steps(state, package_version1, package_version2) is None
+        assert (
+            resolver._run_steps(
+                state,
+                {
+                    package_version1.name: [package_version1],
+                    package_version2.name: [package_version2],
+                },
+            )
+            is None
+        )
         assert resolver.beam.size == 0
 
     def test_run_steps_no_package_clash(self, resolver: Resolver) -> None:
@@ -351,8 +370,30 @@ class TestResolver(AdviserTestCase):
             ),
         )
 
+        assert (
+            len(resolver.pipeline.steps) == 1
+        ), "A pre-requisite for this test case is to have exactly one step in the pipeline configuration"
+        assert (
+            resolver.pipeline.steps[0].MULTI_PACKAGE_RESOLUTIONS is False
+        ), "This test expect multi package resolution in pipeline step turned off"
+
+        # Should be called only once with package_version2, no package_version1 call as
+        # MULTI_PACKAGE_RESOLUTIONS is off.
+        resolver.pipeline.steps[0].should_receive("run").with_args(
+            state, package_version2
+        ).and_return(None).once()
+
         assert resolver.beam.size == 0
-        assert resolver._run_steps(state, package_version1, package_version2) is None
+        assert (
+            resolver._run_steps(
+                state,
+                {
+                    package_version1.name: [package_version1],
+                    package_version2.name: [package_version2],
+                },
+            )
+            is None
+        )
         assert resolver.beam.size == 1
         assert resolver.beam.top().to_dict() == {
             "advised_runtime_environment": None,
@@ -366,6 +407,54 @@ class TestResolver(AdviserTestCase):
                     ("flask", ("flask", "1.12.0", "https://pypi.org/simple")),
                     ("numpy", ("numpy", "1.1.1", "https://pypi.org/simple")),
                 ]
+            ),
+        }
+
+    def test_multi_package_resolutions(self, resolver: Resolver) -> None:
+        """Test resolutions of a same package and call of run method."""
+        pypi = Source("https://pypi.org/simple")
+
+        package_version1 = PackageVersion(
+            name="tensorflow", version="==2.0.0", index=pypi, develop=False
+        )
+
+        state = State(
+            score=1.0,
+            unresolved_dependencies=OrderedDict(
+                [("flask", ("flask", "1.12.0", "https://pypi.org/simple"))]
+            ),
+            resolved_dependencies=OrderedDict(
+                [(package_version1.name, package_version1.to_tuple())]
+            ),
+        )
+
+        assert (
+            len(resolver.pipeline.steps) == 1
+        ), "A pre-requisite for this test case is to have exactly one step in the pipeline configuration"
+
+        resolver.pipeline.steps[0].MULTI_PACKAGE_RESOLUTIONS = True
+
+        # Should be called only once with package_version2, no package_version1 call as
+        # MULTI_PACKAGE_RESOLUTIONS is off.
+        resolver.pipeline.steps[0].should_receive("run").with_args(
+            state, package_version1
+        ).and_return(None).once()
+
+        assert resolver.beam.size == 0
+        assert (
+            resolver._run_steps(state, {package_version1.name: [package_version1]})
+            is None
+        )
+        assert resolver.beam.size == 1
+        assert resolver.beam.top().to_dict() == {
+            "advised_runtime_environment": None,
+            "justification": [],
+            "resolved_dependencies": OrderedDict(
+                [("tensorflow", ("tensorflow", "2.0.0", "https://pypi.org/simple"))]
+            ),
+            "score": 1.0,
+            "unresolved_dependencies": OrderedDict(
+                [("flask", ("flask", "1.12.0", "https://pypi.org/simple"))]
             ),
         }
 
@@ -392,9 +481,46 @@ class TestResolver(AdviserTestCase):
         resolver.pipeline.steps = [steps.Step1()]
 
         with pytest.raises(StepError):
-            assert resolver._run_steps(state, *package_versions[:3])
+            assert resolver._run_steps(
+                state, {pv.name: [pv] for pv in package_versions[:3]}
+            )
 
         assert original_state == state, "State is not untouched"
+
+    def test_run_steps_combinations(
+        self,
+        resolver: Resolver,
+        tf_package_versions: List[PackageVersion],
+        numpy_package_versions: List[PackageVersion]
+    ) -> None:
+        """Test running steps on all the combinations computed during backtracking runs."""
+        state = State()
+
+        # Lists are stored from oldest to newest, reverse order.
+        tf_package_versions.reverse()
+        numpy_package_versions.reverse()
+
+        assert resolver._run_steps(
+            state, {
+                tf_package_versions[0].name: tf_package_versions,
+                numpy_package_versions[0].name: numpy_package_versions,
+            }
+        ) is None
+        assert resolver.beam.size == len(tf_package_versions) * len(numpy_package_versions)
+
+        # The run_steps algorithm is in fact an optimized drop-in replacement for itertools.product with
+        # backtracking baked in. As we accept all combinations, let's verify combinations generated are
+        # sames as in case of itertools.product.
+
+        itertools_products = []
+        for combination in itertools.product(tf_package_versions, numpy_package_versions):
+            itertools_products.append([item.to_tuple() for item in combination])
+
+        run_steps_products = []
+        for state in resolver.beam.iter_states():
+            run_steps_products.append([item for item in state.unresolved_dependencies.values()])
+
+        assert itertools_products == run_steps_products
 
     def test_run_strides(self, resolver: Resolver) -> None:
         """Test running pipeline strides."""

--- a/thoth/adviser/beam.py
+++ b/thoth/adviser/beam.py
@@ -176,7 +176,15 @@ class Beam:
 
     def top(self) -> State:
         """Return the highest rated state as kept in the beam."""
-        return self._states[-1]
+        if len(self._states) == 0:
+            raise IndexError("Heap is empty")
+
+        result = self._states[len(self._states) // 2]
+        for item in self._states[1 + len(self._states) // 2:]:
+            if result < item:
+                result = item
+
+        return result
 
     def add_state(self, state: State) -> None:
         """Add candidate to the internal candidates listing."""

--- a/thoth/adviser/context.py
+++ b/thoth/adviser/context.py
@@ -111,7 +111,7 @@ class Context:
         return False
 
     def register_accepted_final_state(self, state: State) -> None:
-        """Register an accepted state by the resolution pipeline"""
+        """Register an accepted state by the resolution pipeline."""
         # We keep only `count' states as that was requested by pipeline caller.
         if self.count is not None and len(self._accepted_states) >= self.count:
             heapq.heappushpop(self._accepted_states, state)

--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -23,7 +23,6 @@ from typing import Dict
 from typing import Tuple
 from typing import Any
 from typing import Optional
-from typing import Set
 from typing import List
 import logging
 from itertools import chain
@@ -246,14 +245,12 @@ class Resolver:
         for package_version in package_versions:
             package_version_tuple = package_version.to_tuple()
 
-            if package_version.name in state.unresolved_dependencies:
-                if state.unresolved_dependencies[package_version.name] != package_version_tuple:
-                    # TODO: create a test case for this
+            if package_version.name in state.resolved_dependencies:
+                if state.resolved_dependencies[package_version.name] != package_version_tuple:
                     # We already have the given dependency - there is a dependency clash (same name,
                     # different version or index url). Such state is invalid.
                     return None
                 else:
-                    # TODO: create a test case for this
                     # We already have this dependency in stack, continue to the next one (two packages
                     # depend on the same package and the resolution is valid - no clash).
                     continue

--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -579,7 +579,6 @@ class Resolver:
             return None
 
         for dependency_name, dependency_tuples in all_dependencies.items():
-            print(dependency_tuples)
             package_versions = [self.context.get_package_version(d) for d in dependency_tuples]
             package_versions = self._semver_sort_and_limit_latest_versions(package_versions)
             package_versions = list(self._run_sieves(package_versions))

--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -641,6 +641,7 @@ class Resolver:
                 if self._run_strides(final_state):
                     self._run_wraps(final_state)
                     self.context.accepted_final_states_count += 1
+                    self.context.register_accepted_final_state(final_state)
                     yield final_state
                 else:
                     self.context.discarded_final_states_count += 1

--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -26,7 +26,7 @@ from typing import Optional
 from typing import List
 import logging
 from itertools import chain
-from itertools import product as itertools_product
+from collections import deque
 
 from thoth.python import PackageVersion
 from thoth.python import Project
@@ -150,9 +150,7 @@ class Resolver:
         converter=_limit_latest_versions,  # type: ignore
     )
 
-    _beam = attr.ib(
-        type=Optional[Beam], kw_only=True, default=None
-    )
+    _beam = attr.ib(type=Optional[Beam], kw_only=True, default=None)
     _solver = attr.ib(
         type=Optional[PythonPackageGraphSolver], kw_only=True, default=None
     )
@@ -209,7 +207,9 @@ class Resolver:
                     f"Failed to run pipeline boot {boot.__class__.__name__!r}: {str(exc)}"
                 ) from exc
 
-    def _run_sieves(self, package_versions: List[PackageVersion]) -> Generator[PackageVersion, None, None]:
+    def _run_sieves(
+        self, package_versions: List[PackageVersion]
+    ) -> Generator[PackageVersion, None, None]:
         """Run sieves on each package tuple."""
         result = (pv for pv in package_versions)
         for sieve in self.pipeline.sieves:
@@ -232,11 +232,10 @@ class Resolver:
 
         yield from result
 
-    def _run_steps(
+    def _do_run_steps(
         self, state: State, *package_versions: PackageVersion
-    ) -> None:
+    ) -> Optional[Tuple[List[Tuple[str, str, str]], float, List[Dict[str, Any]]]]:
         """Run steps to score next state or filter out invalid steps."""
-        # We clone new state once we are sure we create it. Meantime, keep track of changes but be lazy.
         new_state_unresolved_dependencies = []
         new_state_add_justification = []
         new_state_score = state.score
@@ -246,7 +245,10 @@ class Resolver:
             package_version_tuple = package_version.to_tuple()
 
             if package_version.name in state.resolved_dependencies:
-                if state.resolved_dependencies[package_version.name] != package_version_tuple:
+                if (
+                    state.resolved_dependencies[package_version.name]
+                    != package_version_tuple
+                ):
                     # We already have the given dependency - there is a dependency clash (same name,
                     # different version or index url). Such state is invalid.
                     return None
@@ -261,7 +263,7 @@ class Resolver:
                     step_result = step.run(state, package_version)
                 except NotAcceptable as exc:
                     _LOGGER.debug(
-                        "Step %r discarded addition of package %r in combination %r: %s",
+                        "Step %r discarded addition of package %r: %s",
                         step.__class__.__name__,
                         package_version.to_tuple(),
                         package_version_tuples,
@@ -284,19 +286,101 @@ class Resolver:
 
             new_state_unresolved_dependencies.append(package_version.to_tuple())
 
-        # We accept a new score, perform actual clone now.
-        new_state = state.clone()
-        new_state.score = new_state_score
-        new_state.add_justification(new_state_add_justification)
-        for unresolved_dependency in new_state_unresolved_dependencies:
-            new_state.add_unresolved_dependency(unresolved_dependency)
-
         _LOGGER.debug(
-            "Adding a new state with new entries %r: %r",
-            package_version_tuples,
-            new_state,
+            "Steps accepted a new state with new entries %r", package_version_tuples
         )
-        self.beam.add_state(new_state)
+        return (
+            new_state_unresolved_dependencies,
+            new_state_score,
+            new_state_add_justification,
+        )
+
+    def _run_steps(
+        self, state: State, package_versions_dict: Dict[str, List[PackageVersion]]
+    ) -> None:
+        """Run steps and generate a new state.
+
+        The algorithm under the hood performs backtracking to make sure each step is run once on
+        the given state. This guarantees less calls to steps making the pipeline more efficient.
+        """
+        configuration_table = tuple(package_versions_dict.values())
+        configuration_queue = deque([((0, 0), state)])
+
+        while configuration_queue:
+            idx, state = configuration_queue.popleft()
+            package_version = configuration_table[idx[0]][idx[1]]
+            package_version_tuple = package_version.to_tuple()
+
+            multi_package_resolution = False
+            if package_version.name in state.resolved_dependencies:
+                if (
+                    state.resolved_dependencies[package_version.name]
+                    != package_version_tuple
+                ):
+                    # We already have the given dependency - there is a dependency clash (same name,
+                    # different version or index url). Such state is invalid, drop it.
+                    continue
+                else:
+                    # We already have this dependency in stack, run steps that are required to be run in such cases.
+                    multi_package_resolution = True
+
+            score_addition = 0.0
+            justification_addition = []
+            for step in self.pipeline.steps:
+                _LOGGER.debug("Running step %r", step.__class__.__name__)
+
+                if multi_package_resolution and not step.MULTI_PACKAGE_RESOLUTIONS:
+                    _LOGGER.debug(
+                        "Skipping running step %r - this step was already run for package %r "
+                        "and step has no MULTI_PACKAGE_RESOLUTIONS flag set",
+                        step.__class__.__name__,
+                        package_version_tuple,
+                    )
+                    continue
+
+                try:
+                    step_result = step.run(state, package_version)
+                except NotAcceptable as exc:
+                    _LOGGER.debug(
+                        "Step %r discarded addition of package %r in combination %r: %s",
+                        step.__class__.__name__,
+                        package_version_tuple,
+                        str(exc),
+                    )
+                    break
+                except Exception as exc:
+                    raise StepError(
+                        f"Failed to run step {step.__class__.__name__!r} for Python package "
+                        f"{package_version_tuple!r}: {str(exc)}"
+                    ) from exc
+
+                if step_result:
+                    step_score_addition, step_justification_addition = step_result
+
+                    if step_score_addition is not None:
+                        score_addition += step_score_addition
+
+                    if step_justification_addition is not None:
+                        justification_addition.extend(step_justification_addition)
+            else:
+                if idx[1] + 1 < len(configuration_table[idx[0]]):
+                    configuration_queue.append(((idx[0], idx[1] + 1), state.clone()))
+
+                if not multi_package_resolution:
+                    # Do NOT re-add package if it was already resolved.
+                    state.add_unresolved_dependency(package_version_tuple)
+
+                state.add_justification(justification_addition)
+                state.score += score_addition
+
+                if len(configuration_table) == idx[0] + 1:
+                    # No more to run - we passed all package_version of a type.
+                    self.beam.add_state(state.clone())
+                    if configuration_queue:
+                        # Pop last item from the queue to act like in case of back tracking.
+                        configuration_queue.appendleft(configuration_queue.pop())
+                else:
+                    configuration_queue.appendleft(((idx[0] + 1, 0), state))
 
     def _run_strides(self, state: State) -> bool:
         """Run strides and check if the given state should be accepted."""
@@ -346,7 +430,9 @@ class Resolver:
         if not resolved_direct_dependencies:
             raise UnresolvedDependencies(
                 "No direct dependencies were resolved",
-                unresolved=[pv.name for pv in self.project.iter_dependencies(with_devel=True)],
+                unresolved=[
+                    pv.name for pv in self.project.iter_dependencies(with_devel=True)
+                ],
             )
 
         unresolved = []
@@ -401,7 +487,7 @@ class Resolver:
             _LOGGER.debug(
                 "Limiting latest versions of packages to %d", self.limit_latest_versions
             )
-            return sorted_package_versions[:self.limit_latest_versions]
+            return sorted_package_versions[: self.limit_latest_versions]
 
         return sorted_package_versions
 
@@ -417,7 +503,9 @@ class Resolver:
             for direct_dependency in package_versions:
                 self.context.register_package_version(direct_dependency)
 
-            package_versions = self._semver_sort_and_limit_latest_versions(package_versions)
+            package_versions = self._semver_sort_and_limit_latest_versions(
+                package_versions
+            )
             package_versions = list(self._run_sieves(package_versions))
             if not package_versions:
                 raise CannotProduceStack(
@@ -445,8 +533,11 @@ class Resolver:
 
             for state in states:
                 for package_version in package_versions:
-                    # TODO: use back tracking here
-                    self._run_steps(state, package_version)
+                    # Perform clone as run_steps can modify state which would be propagated to all subsequent
+                    # run_steps calls.
+                    self._run_steps(
+                        state.clone(), {package_version.name: [package_version]}
+                    )
 
     def _expand_state(self, state: State) -> Optional[State]:
         """Expand the given state, generate new states respecting the pipeline configuration."""
@@ -489,17 +580,19 @@ class Resolver:
         self._expand_state_add_dependencies(
             state=state,
             package_version=package_version,
-            dependencies=list(chain(*dependencies.values()))
+            dependencies=list(chain(*dependencies.values())),
         )
 
     def _expand_state_add_dependencies(
         self,
         state: State,
         package_version: PackageVersion,
-        dependencies: List[Tuple[str, str]]
+        dependencies: List[Tuple[str, str]],
     ) -> None:
         """Create new states out of existing ones based on dependencies."""
-        _LOGGER.debug("Expanding state with dependencies based on packages solved in environments")
+        _LOGGER.debug(
+            "Expanding state with dependencies based on packages solved in environments"
+        )
 
         package_tuple = package_version.to_tuple()
         all_dependencies: Dict[str, List[Tuple[str, str, str]]] = {}
@@ -518,7 +611,8 @@ class Resolver:
                     _LOGGER.debug(
                         "Removing package %r in version %r from dependency graph as it will not be installed into "
                         "the given runtime environment",
-                        dependency_name, dependency_version,
+                        dependency_name,
+                        dependency_version,
                     )
                     continue
 
@@ -542,7 +636,9 @@ class Resolver:
                     record["package_version"],
                     record["index_url"],
                 )
-                if not self.context.get_package_version(dependency_tuple, graceful=True):
+                if not self.context.get_package_version(
+                    dependency_tuple, graceful=True
+                ):
                     environment_marker = self.graph.get_python_environment_marker(
                         *package_tuple,
                         dependency_name=dependency_tuple[0],
@@ -576,8 +672,12 @@ class Resolver:
             return None
 
         for dependency_name, dependency_tuples in all_dependencies.items():
-            package_versions = [self.context.get_package_version(d) for d in dependency_tuples]
-            package_versions = self._semver_sort_and_limit_latest_versions(package_versions)
+            package_versions = [
+                self.context.get_package_version(d) for d in dependency_tuples
+            ]
+            package_versions = self._semver_sort_and_limit_latest_versions(
+                package_versions
+            )
             package_versions = list(self._run_sieves(package_versions))
             if not package_versions:
                 _LOGGER.debug(
@@ -588,13 +688,7 @@ class Resolver:
 
             all_dependencies[dependency_name] = package_versions
 
-        for combination_package_versions in itertools_product(
-            *all_dependencies.values()
-        ):
-            # TODO: use back tracking here
-            self._run_steps(state, *combination_package_versions)
-
-        return None
+        self._run_steps(state, all_dependencies)
 
     def _do_resolve_states(
         self, *, with_devel: bool = True
@@ -603,11 +697,17 @@ class Resolver:
         self._run_boots()
         self._prepare_initial_states(with_devel=with_devel)
 
-        _LOGGER.info("Hold tight, Thoth is computing recommendations for your application...")
+        _LOGGER.info(
+            "Hold tight, Thoth is computing recommendations for your application..."
+        )
 
         self.context.iteration = 0
         while True:
-            if self.context.accepted_final_states_count + self.context.discarded_final_states_count >= self.limit:
+            if (
+                self.context.accepted_final_states_count
+                + self.context.discarded_final_states_count
+                >= self.limit
+            ):
                 _LOGGER.info(
                     "Reached limit of stacks to be generated - %r (limit is %r), stopping resolver "
                     "with the current beam size %d",
@@ -670,7 +770,7 @@ class Resolver:
             for final_state in self._do_resolve_states(with_devel=with_devel):
                 _LOGGER.info(
                     "Pipeline reached a new final state, yielding pipeline product with a score of %g",
-                    final_state.score
+                    final_state.score,
                 )
                 product = Product.from_final_state(
                     graph=self.graph,

--- a/thoth/adviser/state.py
+++ b/thoth/adviser/state.py
@@ -43,14 +43,9 @@ class State:
     advised_runtime_environment = attr.ib(
         type=Optional[RuntimeEnvironment], kw_only=True, default=None
     )
-    _justification = attr.ib(
+    justification = attr.ib(
         type=List[Dict[str, str]], default=attr.Factory(list), kw_only=True
     )
-
-    @property
-    def justification(self) -> List[Dict[str, str]]:
-        """Get justification for the current state."""
-        return self._justification
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert state to a dict representation."""
@@ -63,7 +58,7 @@ class State:
             "unresolved_dependencies": self.unresolved_dependencies,
             "resolved_dependencies": self.resolved_dependencies,
             "advised_runtime_environment": advised_runtime_environment,
-            "justification": self._justification,
+            "justification": self.justification,
         }
 
     def is_final(self) -> bool:
@@ -72,7 +67,7 @@ class State:
 
     def add_justification(self, justification: List[Dict[str, str]]) -> None:
         """Add new entries to the justification field."""
-        self._justification.extend(justification)
+        self.justification.extend(justification)
 
     def add_unresolved_dependency(self, package_tuple: Tuple[str, str, str]) -> None:
         """Add unresolved dependency into the beam."""
@@ -90,11 +85,10 @@ class State:
                 self.advised_runtime_environment.to_dict()
             )
 
-        new_state = self.__class__(
+        return self.__class__(
             score=self.score,
             unresolved_dependencies=OrderedDict(self.unresolved_dependencies),
             resolved_dependencies=OrderedDict(self.resolved_dependencies),
             advised_runtime_environment=cloned_advised_environment,
+            justification=list(self.justification),
         )
-        new_state.add_justification(self.justification)
-        return new_state

--- a/thoth/adviser/step.py
+++ b/thoth/adviser/step.py
@@ -33,7 +33,13 @@ from .unit import Unit
 
 @attr.s(slots=True)
 class Step(Unit):
-    """Step base class implementation."""
+    """Step base class implementation.
+
+    Configuration option MUTLI_PACKAGE_RESOLUTION states whether this state should be run if package
+    is resolved multiple times.
+    """
+
+    MULTI_PACKAGE_RESOLUTIONS = False
 
     @abc.abstractmethod
     def run(


### PR DESCRIPTION
This will guarantee each pipeline step is called once on each state making
the pipeline more efficient - especially with complex (too much time
consuming) steps.

Depends-On: #551 