### PR TITLE
Always bind context

### DIFF
--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1676,7 +1676,7 @@ class TestResolver(AdviserTestCase):
         with pytest.raises(ValueError):
             assert resolver.context, "Context is already bound to resolver"
 
-        resolver.should_receive("resolve_products").with_args(
+        resolver.should_receive("_do_resolve_products").with_args(
             with_devel=False
         ).and_return([]).once()
 
@@ -1686,7 +1686,7 @@ class TestResolver(AdviserTestCase):
     def test_resolve(self, resolver: Resolver) -> None:
         """Test report creation during resolution."""
         product = flexmock(score=1.0)
-        resolver.should_receive("resolve_products").with_args(
+        resolver.should_receive("_do_resolve_products").with_args(
             with_devel=True
         ).and_return([product]).once()
         resolver.pipeline.should_receive("call_post_run_report").once()

--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -725,7 +725,7 @@ class Resolver:
         if self.stop_resolving:
             _LOGGER.warning("Resolving stopped based on SIGINT")
 
-    def resolve_products(
+    def _do_resolve_products(
         self, *, with_devel: bool = True
     ) -> Generator[Product, None, None]:
         """Resolve raw products as produced by this resolver pipeline."""
@@ -778,13 +778,21 @@ class Resolver:
         self.predictor.post_run(self.context)
         self.pipeline.call_post_run()
 
+    def resolve_products(
+            self, *, with_devel: bool = True
+    ) -> Generator[Product, None, None]:
+        """Resolve raw products as produced by this resolver pipeline."""
+        self._init_context()
+        with Unit.assigned_context(self.context):
+            return self._do_resolve_products(with_devel=with_devel)
+
     def resolve(self, *, with_devel: bool = True) -> Report:
         """Resolve software stacks and return resolver report."""
         report = Report(count=self.count, pipeline=self.pipeline)
 
         self._init_context()
         with Unit.assigned_context(self.context):
-            for product in self.resolve_products(with_devel=with_devel):
+            for product in self._do_resolve_products(with_devel=with_devel):
                 report.add_product(product)
 
             if report.product_count() == 0:


### PR DESCRIPTION
This PR addresses issue when resolving only products - the context is not bound
to units.