### PR TITLE
Fork only in the cluster

### DIFF
--- a/openshift/job-adviser-template.yaml
+++ b/openshift/job-adviser-template.yaml
@@ -157,6 +157,8 @@ objects:
                       name: thoth
                 - name: THOTH_DOCUMENT_ID
                   value: "${THOTH_DOCUMENT_ID}"
+                - name: THOTH_ADVISER_FORK
+                  value: "1"
                 - name: THOTH_LOG_ADVISER
                   value: "${THOTH_LOG_ADVISER}"
                 - name: THOTH_ADJUST_LOGGING

--- a/openshift/job-adviser-template.yaml
+++ b/openshift/job-adviser-template.yaml
@@ -5,13 +5,13 @@ metadata:
   annotations:
     description: "Thoth: Adviser"
     openshift.io/display-name: "Thoth: Adviser"
-    version: 0.4.2
+    version: 0.4.3
     tags: thoth,ai-stacks,adviser
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
     template.openshift.io/long-description: >
       This template defines resources needed to run recommendation logic of Thoth to OpenShift.
     template.openshift.io/provider-display-name: "Red Hat, Inc."
-    thoth-station.ninja/template-version: 0.4.2
+    thoth-station.ninja/template-version: 0.4.3
   labels:
     app: thoth
     template: adviser
@@ -117,7 +117,7 @@ objects:
     metadata:
       name: ${THOTH_ADVISER_JOB_ID}
       annotations:
-        thoth-station.ninja/template-version: 0.4.2
+        thoth-station.ninja/template-version: 0.4.3
       labels:
         app: thoth
         component: adviser

--- a/openshift/job-dependencyMonkey-template.yaml
+++ b/openshift/job-dependencyMonkey-template.yaml
@@ -5,13 +5,13 @@ metadata:
   annotations:
     description: "Thoth: Dependency Monkey"
     openshift.io/display-name: "Thoth: Dependency Monkey"
-    version: 0.4.2
+    version: 0.4.3
     tags: thoth,ai-stacks,dependency-monkey
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
     template.openshift.io/long-description: >
       This template defines resources needed to run recommendation logic of Thoth to OpenShift.
     template.openshift.io/provider-display-name: Red Hat, Inc.
-    thoth-station.ninja/template-version: 0.4.2
+    thoth-station.ninja/template-version: 0.4.3
   labels:
     app: thoth
     template: dependency-monkey
@@ -116,7 +116,7 @@ objects:
     metadata:
       name: ${THOTH_DEPENDENCY_MONKEY_JOB_ID}
       annotations:
-        thoth-station.ninja/template-version: 0.4.2
+        thoth-station.ninja/template-version: 0.4.3
       labels:
         app: thoth
         component: dependency-monkey

--- a/openshift/job-dependencyMonkey-template.yaml
+++ b/openshift/job-dependencyMonkey-template.yaml
@@ -152,6 +152,8 @@ objects:
                       name: thoth
                 - name: THOTH_DOCUMENT_ID
                   value: "${THOTH_DOCUMENT_ID}"
+                - name: THOTH_ADVISER_FORK
+                  value: "1"
                 - name: THOTH_LOG_ADVISER
                   value: "${THOTH_LOG_ADVISER}"
                 - name: THOTH_ADVISER_REQUIREMENTS


### PR DESCRIPTION
Do not fork adviser by default, perform fork only in the cluster to correctly
propagate issues encountered during an adviser run (e.g. OOM, CPU time
exceeded, ...).