### PR TITLE
Revert "Add new iteration method for sieves and steps"

### DIFF
--- a/docs/source/developers_guide.rst
+++ b/docs/source/developers_guide.rst
@@ -137,7 +137,7 @@ sources first in the ``../python`` directory, this makes the following code:
 
 to first check sources present in ``../python`` and run code from there
 (instead of running the installed ``thoth-python`` package from `PyPI
-<https://pypi.org/>`__ inside virtual environment).
+<https://pypi.org/>`_ inside virtual environment).
 
 If you would like to run multiple libraries this way, you need to delimit them
 using a colon:
@@ -215,7 +215,7 @@ variable which distinguishes different deployments.
   $ export THOTH_DEPLOYMENT_NAME=thoth-test-core
 
 To browse data stored on Ceph, you can use ``awscli`` utility from `PyPI
-<https://pypi.org/project/awscli/>`__ that provides ``aws`` command (use ``aws
+<https://pypi.org/project/awscli/>`_ that provides ``aws`` command (use ``aws
 s3`` as Ceph exposes S3 compatible API).
 
 To run applications against Thoth's knowledge graph database, see

--- a/docs/source/sieves.rst
+++ b/docs/source/sieves.rst
@@ -39,11 +39,6 @@ same type (same package name).
   packages in the Python ecosystem and each package can have different version
   range requirements on package ``six``.
 
-All sieves have a method called :func:`Sieve.new_iteration
-<thoth.adviser.sieves.Sieve.new_iteration>` that is called each time when a new
-resolution round is made. It is suitable for sieves that keep context that
-is related to resolution iterations.
-
 Main usage
 ==========
 

--- a/docs/source/steps.rst
+++ b/docs/source/steps.rst
@@ -41,12 +41,6 @@ Real world examples section bellow for examples).
   ``Step.MULTI_PACKAGE_RESOLUTIONS`` to ``True`` in derived classes
   implementing step logic.
 
-As steps are, together with :ref:`sieve pipeline units <sieves>`, called during
-resolution to produce new states, each step pipeline unit has a method called
-:func:`Step.new_iteration <thoth.adviser.steps.Step.new_iteration>` (defaults
-to a no-op) that is called each time when a new resolution round is made. It is
-suitable for keeping context that is related to resolution iterations.
-
 Main usage
 ==========
 

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -21,8 +21,6 @@ import flexmock
 
 from thoth.adviser.pipeline_config import PipelineConfig
 from thoth.adviser.report import Report
-from thoth.adviser.sieve import Sieve
-from thoth.adviser.step import Step
 
 from .base import AdviserTestCase
 
@@ -97,17 +95,3 @@ class TestPipelineConfig(AdviserTestCase):
             ).and_return(None).once()
 
         pipeline_config.call_post_run_report(report)
-
-    def test_call_new_iteration(self, pipeline_config: PipelineConfig) -> None:
-        """Test calling new iteration method called on a new resolver round."""
-        assert len(pipeline_config.boots) > 0
-        assert len(pipeline_config.sieves) > 0
-        assert len(pipeline_config.steps) > 0
-        assert len(pipeline_config.strides) > 0
-        assert len(pipeline_config.wraps) > 0
-
-        for unit in pipeline_config.iter_units():
-            if isinstance(unit, (Sieve, Step)):
-                unit.should_receive("new_iteration").with_args().and_return(None).once()
-
-        pipeline_config.call_new_iteration()

--- a/thoth/adviser/pipeline_config.py
+++ b/thoth/adviser/pipeline_config.py
@@ -101,11 +101,3 @@ class PipelineConfig:
                     unit.__class__.__name__,
                     str(exc),
                 ) from exc
-
-    def call_new_iteration(self) -> None:
-        """Notify sieves and steps about new resolver round."""
-        for sieve in self.sieves:
-            sieve.new_iteration()
-
-        for step in self.steps:
-            step.new_iteration()

--- a/thoth/adviser/predictor.py
+++ b/thoth/adviser/predictor.py
@@ -103,3 +103,4 @@ class Predictor:
         ax.patch.set_visible(False)
         for sp in ax.spines.values():
             sp.set_visible(False)
+

--- a/thoth/adviser/sieve.py
+++ b/thoth/adviser/sieve.py
@@ -35,6 +35,3 @@ class Sieve(Unit):
         self, package_versions: Generator[PackageVersion, None, None]
     ) -> Generator[PackageVersion, None, None]:
         """Main entry-point for sieves to filter and score packages."""
-
-    def new_iteration(self) -> None:
-        """A method called on a new resolver round."""

--- a/thoth/adviser/step.py
+++ b/thoth/adviser/step.py
@@ -46,6 +46,3 @@ class Step(Unit):
         self, state: State, package_version: PackageVersion
     ) -> Optional[Tuple[Optional[float], Optional[List[Dict[str, str]]]]]:
         """Main entry-point for steps to filter and score packages."""
-
-    def new_iteration(self) -> None:
-        """A method called on a new resolver round."""


### PR DESCRIPTION
Reverts thoth-station/adviser#619

Let's revert this change - it adds overhead (even thought constant per adviser run). Predictor can use information from `context` that keeps iterations, if such functionality is desired.