### PR TITLE
Do not retrieve markers during resolution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,24 @@ class PredictorMock(Predictor):
 
 
 @pytest.fixture
+def context(project: Project) -> Context:
+    """A fixture for a clean context."""
+    flexmock(Context)
+    flexmock(GraphDatabase)
+    flexmock(Beam)
+
+    return Context(
+        project=project,
+        graph=GraphDatabase(),
+        library_usage=None,
+        limit=100,
+        count=3,
+        beam=Beam(),
+        recommendation_type=RecommendationType.TESTING,
+    )
+
+
+@pytest.fixture
 def pipeline_config() -> PipelineConfig:
     """A fixture for a pipeline configuration with few representatives of each pipeline unit type."""
     flexmock(PipelineConfig)

--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -617,20 +617,14 @@ class Resolver:
                 if not self.context.get_package_version(
                     dependency_tuple, graceful=True
                 ):
-                    environment_marker = self.graph.get_python_environment_marker(
-                        *package_tuple,
-                        dependency_name=dependency_tuple[0],
-                        dependency_version=dependency_tuple[1],
-                        os_name=record["os_name"],
-                        os_version=record["os_version"],
-                        python_version=record["python_version"],
-                    )
                     self.context.register_package_tuple(
                         dependency_tuple,
                         dependent_tuple=package_tuple,
                         develop=package_version.develop,  # Propagate develop flag from parent.
-                        markers=environment_marker,
                         extras=None,
+                        os_name=record["os_name"],
+                        os_version=record["os_version"],
+                        python_version=record["python_version"],
                     )
 
                 if dependency_tuple not in all_dependencies[dependency_tuple[0]]:
@@ -757,8 +751,6 @@ class Resolver:
                     final_state.score,
                 )
                 product = Product.from_final_state(
-                    graph=self.graph,
-                    project=self.project,
                     context=self.context,
                     state=final_state,
                 )


### PR DESCRIPTION
This addresses optimization where we do not need to query database for
environment markers during the actuall resolution. Markers are obtained during
construction of the final stack as needed based on the pipeline result.