### PR TITLE
Limit number of software stacks to 1 on LATEST

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -12,6 +12,8 @@ case $THOTH_ADVISER_SUBCOMMAND in
 		exec /opt/app-root/bin/python3 thoth-adviser dependency-monkey
 		;;
 	'advise')
+		# No need to compute all the stacks, the first one found is sufficient to return.
+		[ "${THOTH_ADVISER_RECOMMENDATION_TYPE}" = "LATEST" ] && THOTH_ADVISER_LIMIT=1
 		exec /opt/app-root/bin/python3 thoth-adviser advise
 		;;
 	*)


### PR DESCRIPTION
No need to compute all the stacks, the first one found is sufficient to return
(its latest).