### PR TITLE
Do not run adviser from bc in debug mode

### DIFF
--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -89,9 +89,9 @@ objects:
             - name: "THOTH_ADVISE"
               value: ${THOTH_ADVISE}
             - name: "THAMOS_VERBOSE"
-              value: "0"
-            - name: "THAMOS_DEBUG"
               value: "1"
+            - name: "THAMOS_DEBUG"
+              value: "0"
             - name: "THAMOS_CONFIG_TEMPLATE"
               value: ".thoth.yaml"
             - name: "THAMOS_CONFIG_EXPAND_ENV"


### PR DESCRIPTION
Do not run adviser from bc in debug mode
Mistakely verbose was switch to 0 instead of debug.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>