### PR TITLE
No deafult value null for metadata

### DIFF
--- a/openshift/adviser-template.yaml
+++ b/openshift/adviser-template.yaml
@@ -48,7 +48,6 @@ parameters:
     required: false
     description: Metadata carried with the adviser request
     displayName: Adviser metadata
-    value: "null"
   - name: THOTH_ADVISER_SEED
     required: true
     description: Random seed to run adviser with.


### PR DESCRIPTION
One task of the inner workflow in the Qeb-Hwt App is failing due to this default value provided in the template. 

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>