### PR TITLE
Use the correct condition for checking parameters

### DIFF
--- a/workflows/templates/finished-webhook-template.yaml
+++ b/workflows/templates/finished-webhook-template.yaml
@@ -42,7 +42,7 @@ spec:
             "origin"
           ]
 
-          if all(p in GITHUB_PARAMETERS for p in metadata):
+          if all(p in metadata for p in GITHUB_PARAMETERS):
             github_webhook_params = (
                 metadata["github_event_type"] is not None,
                 metadata["github_check_run_id"] is not None,


### PR DESCRIPTION
Metadata can have extra parameters not strictly required for GitHub App.

**Context**
```
trigger-finished-webhook:       2020-02-27 10:37:27,787   1 WARNING  thoth.common:275: Logging to a Sentry instance is turned off
trigger-finished-webhook:       2020-02-27 10:37:27,787   1 INFO     thoth.common:297: Logging to rsyslog endpoint is turned off
trigger-finished-webhook:       There are missing keys for GitHub App {'github_event_type': 'thoth_thamos_advise', 'github_check_run_id': 472123141, 'github_installation_id': 6181026, 'github_base_repo_url': 'https://api.github.com/repos/thoth-station/kebechet', 'origin': 'https://github.com/pacospace/kebechet', 'is_s2i': False}
trigger-finished-webhook:       Thamos has run through CLI
```

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>