### PR TITLE
Introduce user stack scoring as a base for comparision

### DIFF
--- a/thoth/adviser/exceptions.py
+++ b/thoth/adviser/exceptions.py
@@ -139,3 +139,7 @@ class CannotProduceStack(AdviserRunException):
     def to_dict(self) -> Optional[Dict[str, str]]:
         """Convert exception to a dict representation for a user."""
         return {"ERROR": "No results were resolved, see logs for more info"}
+
+
+class UserLockFileError(AdviserRunException):
+    """An exception raised when the supplied user stack has issues."""

--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -133,7 +133,6 @@ def _library_usage(value: Any) -> Dict[str, Any]:
 @contextlib.contextmanager
 def _sigint_handler(resolver: "Resolver") -> None:
     """Register signal handler for resolver handling."""
-
     def handler(sig_num: int, _) -> None:
         resolver.stop_resolving = True
 

--- a/thoth/adviser/run.py
+++ b/thoth/adviser/run.py
@@ -53,6 +53,9 @@ def subprocess_run(
     print_func: Callable[[float, Union[Dict[str, Any], List[Any]]], None],
     result_dict: Dict[str, Any],
     plot: Optional[str] = None,
+    *,
+    with_devel: bool = True,
+    user_stack_scoring: bool = True,
 ) -> int:
     """Run the given function (partial annealing method) in a subprocess and output the produced report."""
     start_time = time.monotonic()
@@ -67,7 +70,10 @@ def subprocess_run(
         init_logging()
         _LOGGER.debug("Created a child process to compute report")
         try:
-            report: Union[DependencyMonkeyReport, Report] = resolver.resolve(with_devel=True)
+            report: Union[DependencyMonkeyReport, Report] = resolver.resolve(
+                with_devel=with_devel,
+                user_stack_scoring=user_stack_scoring
+            )
             if plot:
                 parts = plot.rsplit(".", maxsplit=1)
                 file_name = parts[0]


### PR DESCRIPTION
As we are not able to explore the whole state space of all the possible resolved stacks, let's use the user's stack as a base to see if we can find a better stack in comparison to the one user is currently using (based on the lock file submitted to an adviser run).