### PR TITLE
No need to initialize logging multiple times

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class Test(TestCommand):
     """Introduce test command to run testsuite using pytest."""
 
     _IMPLICIT_PYTEST_ARGS = [
-        "--timeout=15",
+        "--timeout=60",
         "--cov=./thoth",
         "--mypy",
         "--capture=no",

--- a/thoth/adviser/run.py
+++ b/thoth/adviser/run.py
@@ -33,8 +33,6 @@ import logging
 import os
 import time
 
-from thoth.common import init_logging
-
 from .exceptions import AdviserRunException
 from .exceptions import UnresolvedDependencies
 from .dependency_monkey import DependencyMonkey
@@ -67,7 +65,6 @@ def subprocess_run(
     if pid == 0:  # Child or no-fork mode.
         return_code = 0
         # We need to re-init logging for the sub-process.
-        init_logging()
         _LOGGER.debug("Created a child process to compute report")
         try:
             report: Union[DependencyMonkeyReport, Report] = resolver.resolve(


### PR DESCRIPTION
This also causes duplicate log messages when JSON logging is turned on.