### PR TITLE
Add option consider/do not consider dev dependencies

### DIFF
--- a/openshift/job-adviser-template.yaml
+++ b/openshift/job-adviser-template.yaml
@@ -5,13 +5,13 @@ metadata:
   annotations:
     description: "Thoth: Adviser"
     openshift.io/display-name: "Thoth: Adviser"
-    version: 0.4.6
+    version: 0.4.7
     tags: thoth,ai-stacks,adviser
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
     template.openshift.io/long-description: >
       This template defines resources needed to run recommendation logic of Thoth to OpenShift.
     template.openshift.io/provider-display-name: "Red Hat, Inc."
-    thoth-station.ninja/template-version: 0.4.6
+    thoth-station.ninja/template-version: 0.4.7
   labels:
     app: thoth
     template: adviser-workload-operator
@@ -74,6 +74,11 @@ parameters:
     # Keep seed constant across adviser runs so that two runs with same knowledge base report same results to user.
     # Not to answer with a different stack each time a request is made.
     value: "42"
+  - name: THOTH_ADVISER_DEV
+    required: true
+    description: Consider also development dependencies.
+    displayName: Dev dependencies
+    value: "0"
   - name: THOTH_ADVISER_BEAM_WIDTH
     required: true
     description: Adviser's beam width to restrict memory requirements with states generated.
@@ -116,7 +121,7 @@ objects:
     metadata:
       name: ${THOTH_ADVISER_JOB_ID}
       annotations:
-        thoth-station.ninja/template-version: 0.4.6
+        thoth-station.ninja/template-version: 0.4.7
       labels:
         app: thoth
         component: adviser-workload-operator
@@ -184,6 +189,8 @@ objects:
                   value: "${THOTH_ADVISER_RUNTIME_ENVIRONMENT}"
                 - name: THOTH_ADVISER_SEED
                   value: "${THOTH_ADVISER_SEED}"
+                - name: THOTH_ADVISER_DEV
+                  value: "${THOTH_ADVISER_DEV}"
                 - name: THOTH_ADVISER_BEAM_WIDTH
                   value: "${THOTH_ADVISER_BEAM_WIDTH}"
                 - name: THOTH_ADVISER_SUBCOMMAND

--- a/openshift/job-dependencyMonkey-template.yaml
+++ b/openshift/job-dependencyMonkey-template.yaml
@@ -5,13 +5,13 @@ metadata:
   annotations:
     description: "Thoth: Dependency Monkey"
     openshift.io/display-name: "Thoth: Dependency Monkey"
-    version: 0.4.6
+    version: 0.4.7
     tags: thoth,ai-stacks,dependency-monkey
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
     template.openshift.io/long-description: >
       This template defines resources needed to run recommendation logic of Thoth to OpenShift.
     template.openshift.io/provider-display-name: Red Hat, Inc.
-    thoth-station.ninja/template-version: 0.4.6
+    thoth-station.ninja/template-version: 0.4.7
   labels:
     app: thoth
     template: dependency-monkey-workload-operator
@@ -79,6 +79,10 @@ parameters:
     # Keep seed constant across adviser runs so that two runs with same knowledge base report same results to user.
     # Not to answer with a different stack each time a request is made.
     value: "42"
+  - name: THOTH_ADVISER_DEV
+    required: false
+    description: Consider also development dependencies.
+    value: "0"
   - name: THOTH_DEPENDENCY_MONKEY_DECISION_TYPE
     required: false
     description:
@@ -111,7 +115,7 @@ objects:
     metadata:
       name: ${THOTH_DEPENDENCY_MONKEY_JOB_ID}
       annotations:
-        thoth-station.ninja/template-version: 0.4.6
+        thoth-station.ninja/template-version: 0.4.7
       labels:
         app: thoth
         component: dependency-monkey
@@ -167,6 +171,8 @@ objects:
                   value: "${THOTH_DEPENDENCY_MONKEY_REPORT_OUTPUT}"
                 - name: THOTH_DEPENDENCY_MONKEY_SEED
                   value: "${THOTH_DEPENDENCY_MONKEY_SEED}"
+                - name: THOTH_ADVISER_DEV
+                  value: "${THOTH_ADVISER_DEV}"
                 - name: THOTH_DEPENDENCY_MONKEY_DECISION_TYPE
                   value: "${THOTH_DEPENDENCY_MONKEY_DECISION_TYPE}"
                 - name: THOTH_DEPENDENCY_MONKEY_DRY_RUN

--- a/thoth/adviser/cli.py
+++ b/thoth/adviser/cli.py
@@ -385,6 +385,14 @@ def provenance(
          "as a base for relative stack quality comparision. Adviser will score the supplied "
          "lock file and will try to find a better stack.",
 )
+@click.option(
+    "--dev/--no-dev",
+    envvar="THOTH_ADVISER_DEV",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Consider or do not consider development dependencies during resolution.",
+)
 def advise(
     click_ctx: click.Context,
     *,
@@ -405,6 +413,7 @@ def advise(
     seed: Optional[int] = None,
     pipeline: Optional[str] = None,
     user_stack_scoring: bool = True,
+    dev: bool = False,
 ):
     """Advise package and package versions in the given stack or on solely package only."""
     parameters = locals()
@@ -471,7 +480,7 @@ def advise(
         print_func,
         plot=plot,
         result_dict={"parameters": parameters},
-        with_devel=True,
+        with_devel=dev,
         user_stack_scoring=user_stack_scoring,
     )
 
@@ -604,6 +613,14 @@ def advise(
     metavar="PIPELINE",
     help="Pipeline configuration supplied in a form of JSON/YAML or a path to a file.",
 )
+@click.option(
+    "--dev/--no-dev",
+    envvar="THOTH_ADVISER_DEV",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Consider or do not consider development dependencies during resolution.",
+)
 def dependency_monkey(
     click_ctx: click.Context,
     *,
@@ -624,6 +641,7 @@ def dependency_monkey(
     runtime_environment: str = None,
     seed: Optional[int] = None,
     pipeline: Optional[str] = None,
+    dev: bool = False,
 ):
     """Generate software stacks based on all valid resolutions that conform version ranges."""
     parameters = locals()
@@ -703,7 +721,7 @@ def dependency_monkey(
         print_func,
         result_dict={"parameters": parameters},
         plot=plot,
-        with_devel=True,
+        with_devel=dev,
         user_stack_scoring=False,
     )
 

--- a/thoth/adviser/run.py
+++ b/thoth/adviser/run.py
@@ -58,6 +58,9 @@ def subprocess_run(
     user_stack_scoring: bool = True,
 ) -> int:
     """Run the given function (partial annealing method) in a subprocess and output the produced report."""
+    if not with_devel:
+        _LOGGER.warning("Development dependencies will not be taken into account")
+
     start_time = time.monotonic()
 
     pid = 0

--- a/workflows/templates/advise-template.yaml
+++ b/workflows/templates/advise-template.yaml
@@ -4,7 +4,7 @@ kind: WorkflowTemplate
 metadata:
   name: advise
   annotations:
-    thoth-station.ninja/template-version: 0.6.0
+    thoth-station.ninja/template-version: 0.6.1
   labels:
     app: thoth
     component: advise
@@ -24,6 +24,8 @@ spec:
           - name: THOTH_ADVISER_METADATA
           - name: THOTH_ADVISER_SEED
             value: "42"
+          - name: THOTH_ADVISER_DEV
+            value: "0"
           - name: THOTH_ADVISER_BEAM_WIDTH
             value: "1000"
           - name: THOTH_LOG_ADVISER
@@ -97,6 +99,8 @@ spec:
             value: "{{inputs.parameters.THOTH_ADVISER_METADATA}}"
           - name: THOTH_ADVISER_SEED
             value: "{{inputs.parameters.THOTH_ADVISER_SEED}}"
+          - name: THOTH_ADVISER_DEV
+            value: "{{inputs.parameters.THOTH_ADVISER_DEV}}"
           - name: THOTH_ADVISER_BEAM_WIDTH
             value: "{{inputs.parameters.THOTH_ADVISER_BEAM_WIDTH}}"
           - name: THOTH_ADVISER_SUBCOMMAND


### PR DESCRIPTION
When running advises for s2i, we do not need to consider development dependencies used for testing the application as the application is deployed. This, in many cases, reduces number of packages considered and the size of the dependency graph explored.