### PR TITLE
Fix info message causing issues when the beam is empty

### DIFF
--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -1068,13 +1068,13 @@ class Resolver:
                 ) % self.log_final_state_count == 0:
                     _LOGGER.info(
                         "Pipeline reached %d final states out of %d requested in iteration %d "
-                        "(pipeline pace %.02f stacks/second), top rated software stack has a score of %g",
+                        "(pipeline pace %.02f stacks/second), top rated software stack has a score of %s",
                         self.context.accepted_final_states_count,
                         self.context.limit,
                         self.context.iteration,
                         self.context.accepted_final_states_count
                         / (time.monotonic() - start_time),
-                        self.beam.max().score,
+                        self.beam.max().score if self.beam.size > 0 else "N/A",
                     )
 
                 product = Product.from_final_state(


### PR DESCRIPTION
If the last state turns to be a last resolved software stack, the info message
raises error.

Fixes: https://github.com/thoth-station/adviser/issues/897