### PR TITLE
Introduce heat up phase for the latest predictor

### DIFF
--- a/tests/predictors/test_latest.py
+++ b/tests/predictors/test_latest.py
@@ -17,6 +17,8 @@
 
 """Test implementation of predictor approximating latest resolution."""
 
+from collections import OrderedDict
+
 import flexmock
 from hypothesis import given
 from hypothesis.strategies import integers
@@ -43,6 +45,8 @@ class TestApproximatingLatest(AdviserTestCase):
             beam.add_state(cloned_state)
 
         predictor = ApproximatingLatest()
+        # Add an item to the heat up entry so that assume the heat-up process was already done.
+        predictor._packages_heated_up = {"some-package"}
         context = flexmock(accepted_final_states_count=33, beam=beam)
         with predictor.assigned_context(context):
             next_state, package_tuple = predictor.run()
@@ -50,3 +54,106 @@ class TestApproximatingLatest(AdviserTestCase):
             assert next_state in beam.iter_states()
             assert package_tuple[0] in next_state.unresolved_dependencies
             assert package_tuple in next_state.unresolved_dependencies[package_tuple[0]].values()
+
+    def test_heat_up(self) -> None:
+        """Test the heat up phase."""
+        beam = Beam()
+
+        dependency_tuple_1 = ("tensorflow", "2.1.0", "https://pypi.org/simple")
+        dependency_tuple_2 = ("tensorflow", "2.0.0", "https://pypi.org/simple")
+        dependency_tuple_3 = ("tensorflow", "1.15.0", "https://pypi.org/simple")
+        dependency_tuple_4 = ("flask", "1.1.1", "https://pypi.org/simple")
+        dependency_tuple_5 = ("flask", "1.0", "https://pypi.org/simple")
+
+        state = State(
+            score=0.999,
+            resolved_dependencies=OrderedDict(),
+            unresolved_dependencies=OrderedDict((
+                (
+                    "tensorflow", OrderedDict((
+                        (hash(dependency_tuple_1), dependency_tuple_1),
+                        (hash(dependency_tuple_2), dependency_tuple_2),
+                        (hash(dependency_tuple_3), dependency_tuple_3),
+                    ))
+                ),
+                (
+                    "flask", OrderedDict((
+                        (hash(dependency_tuple_4), dependency_tuple_4),
+                        (hash(dependency_tuple_5), dependency_tuple_5),
+                    ))
+                )
+            )),
+        )
+
+        beam.add_state(state)
+
+        predictor = ApproximatingLatest()
+        context = flexmock(accepted_final_states_count=0, beam=beam)
+
+        assert not predictor._packages_heated_up
+        with predictor.assigned_context(context):
+            next_state, package_tuple = predictor.run()
+
+        assert next_state is state
+        assert "tensorflow" in predictor._packages_heated_up
+        assert package_tuple is dependency_tuple_1
+
+        with predictor.assigned_context(context):
+            next_state, package_tuple = predictor.run()
+
+        assert next_state is state
+        assert "tensorflow" in predictor._packages_heated_up
+        assert "flask" in predictor._packages_heated_up
+        assert package_tuple is dependency_tuple_4
+
+    def test_heat_up_end(self) -> None:
+        """Test the end of the heat up phase."""
+        flexmock(Beam)
+        beam = Beam()
+
+        dependency_tuple_1 = ("tensorflow", "2.1.0", "https://pypi.org/simple")
+        dependency_tuple_2 = ("tensorflow", "2.0.0", "https://pypi.org/simple")
+        dependency_tuple_3 = ("tensorflow", "1.15.0", "https://pypi.org/simple")
+        dependency_tuple_4 = ("flask", "1.1.1", "https://pypi.org/simple")
+        dependency_tuple_5 = ("flask", "1.0", "https://pypi.org/simple")
+
+        state = State(
+            score=0.999,
+            resolved_dependencies=OrderedDict(),
+            unresolved_dependencies=OrderedDict((
+                (
+                    "tensorflow", OrderedDict((
+                        (hash(dependency_tuple_1), dependency_tuple_1),
+                        (hash(dependency_tuple_2), dependency_tuple_2),
+                        (hash(dependency_tuple_3), dependency_tuple_3),
+                    ))
+                ),
+                (
+                    "flask", OrderedDict((
+                        (hash(dependency_tuple_4), dependency_tuple_4),
+                        (hash(dependency_tuple_5), dependency_tuple_5),
+                    ))
+                )
+            )),
+        )
+
+        beam.add_state(state)
+
+        last_state = flexmock(score=100)
+        first_unresolved_dependency = flexmock()
+        last_state.should_receive("get_first_unresolved_dependency").and_return(first_unresolved_dependency).once()
+        beam.should_receive("get_last").and_return(last_state).once()
+
+        flexmock(ApproximatingLatest)
+        predictor = ApproximatingLatest()
+        predictor._initial_state = state
+        context = flexmock(accepted_final_states_count=0, beam=beam)
+
+        predictor._packages_heated_up.add("tensorflow")
+        predictor._packages_heated_up.add("flask")
+
+        with predictor.assigned_context(context):
+            next_state, package_tuple = predictor.run()
+
+        assert package_tuple is first_unresolved_dependency
+        assert next_state is last_state

--- a/thoth/adviser/predictors/latest.py
+++ b/thoth/adviser/predictors/latest.py
@@ -21,7 +21,9 @@ import logging
 import math
 
 import attr
+from typing import Optional
 from typing import Tuple
+from typing import Set
 
 from .hill_climbing import HillClimbing
 from ..state import State
@@ -41,15 +43,22 @@ class ApproximatingLatest(HillClimbing):
 
     _hop = attr.ib(type=bool, default=False)
     _hop_logged = attr.ib(type=bool, default=False)
+    _packages_heated_up = attr.ib(type=Set[str], factory=set)
+    _initial_state = attr.ib(type=Optional[State], default=None)
+    _latest_versions_heat_up = attr.ib(type=set, factory=set)
 
-    def set_reward_signal(self, state: State, package_tuple: Tuple[str, str, str], reward: float) -> None:
+    def set_reward_signal(
+        self, state: State, package_tuple: Tuple[str, str, str], reward: float
+    ) -> None:
         """Set hop to True if we did not get resolve any stack with latest."""
         super().set_reward_signal(state, package_tuple, reward)
 
         if math.isnan(reward):
             self._hop = True
             if not self._hop_logged:
-                _LOGGER.warning("The latest stack couldn't be resolved, performing hops across package versions")
+                _LOGGER.warning(
+                    "The latest stack couldn't be resolved, performing hops across package versions"
+                )
                 self._hop_logged = True
 
         if math.isinf(reward):
@@ -60,16 +69,73 @@ class ApproximatingLatest(HillClimbing):
         super().pre_run()
         self._hop = False
         self._hop_logged = False
+        self._initial_state = None
+        self._packages_heated_up.clear()
+
+    def _heat_up(self) -> Optional[Tuple[State, Tuple[str, str, str]]]:
+        """Start heating up phase for the predictor.
+
+        This phase generates new states out of the initial state so that the predictor is not stuck
+        in states generated out of the very first state and very first dependency.
+        """
+        if not self._packages_heated_up:
+            assert self.context.beam.size == 1
+            self._initial_state = self.context.beam.get(0)
+
+        # Keeping the initial state as an attribute in this predictor and this
+        # check is an optimization thanks to the logic behind resolver's state
+        # manipulation - it reuses the initial state for generating new states
+        # (see memory optimization) - if the initial state starts to have
+        # resolved dependencies, it means there are no more unresolved
+        # dependencies to be tracked or the newly cloned state out of the
+        # initial state would be the same as the initial state.
+        if self._initial_state.resolved_dependencies:
+            # End the heat up phase.
+            self._initial_state = None
+            return None
+
+        for unresolved_dependency in self._initial_state.unresolved_dependencies:
+            if unresolved_dependency in self._packages_heated_up:
+                continue
+
+            self._packages_heated_up.add(unresolved_dependency)
+            unresolved_dependency_tuple = next(
+                iter(
+                    self._initial_state.unresolved_dependencies[
+                        unresolved_dependency
+                    ].values()
+                )
+            )
+
+            if self.keep_history:
+                self._history.append(
+                    (
+                        self._initial_state.score,
+                        self.context.accepted_final_states_count,
+                    )
+                )
+
+            return self._initial_state, unresolved_dependency_tuple
+
+        self._initial_state = None
+        return None
 
     def run(self) -> Tuple[State, Tuple[str, str, str]]:
         """Get last state expanded and expand first unresolved dependency."""
+        if not self._packages_heated_up or self._initial_state:
+            heat_up_result = self._heat_up()
+            if heat_up_result is not None:
+                return heat_up_result
+
         state = self.context.beam.get_last()
 
         if state is None:
             state = self.context.beam.get_random()
 
         if self.keep_history:
-            self._history.append((state.score, self.context.accepted_final_states_count))
+            self._history.append(
+                (state.score, self.context.accepted_final_states_count)
+            )
 
         if self._hop:
             return state, state.get_random_unresolved_dependency(prefer_recent=True)


### PR DESCRIPTION
This phase will generate new states out of the initial state. The newly
generated states are always generated from the latest possible direct
dependnecy found in the stack. This way we minimalize a possibility to of
getting stuck during predictions in a local area in the state space where we do
not lead to any final state. This addresses the OOM issue spotted in the stage
environment when resolving latest stacks.