### PR TITLE
Adviser Dev env var added to template

### DIFF
--- a/openshift/adviser-template.yaml
+++ b/openshift/adviser-template.yaml
@@ -55,6 +55,11 @@ parameters:
     # Keep seed constant across adviser runs so that two runs with same knowledge base report same results to user.
     # Not to answer with a different stack each time a request is made.
     value: "42"
+  - name: THOTH_ADVISER_DEV
+    required: true
+    description: Consider also development dependencies.
+    displayName: Dev dependencies
+    value: "0"
   - name: THOTH_ADVISER_BEAM_WIDTH
     required: true
     description: Adviser's beam width to restrict memory requirements with states generated.
@@ -148,6 +153,8 @@ objects:
             value: "${THOTH_ADVISER_RUNTIME_ENVIRONMENT}"
           - name: THOTH_ADVISER_METADATA
             value: "${THOTH_ADVISER_METADATA}"
+          - name: THOTH_ADVISER_DEV
+            value: "${THOTH_ADVISER_DEV}"
           - name: THOTH_ADVISER_SEED
             value: "${THOTH_ADVISER_SEED}"
           - name: THOTH_ADVISER_BEAM_WIDTH


### PR DESCRIPTION
Adviser Dev env var added to template
observed in MOC:
{"name": "thoth.common.openshift", "levelname": "WARNING", "module": "openshift", "lineno": 232, "funcname": "set_template_parameters", "created": 1587582556.219331, "asctime": "2020-04-22 19:09:16,219", "msecs": 219.3310260772705, "relative_created": 502981029.4058323, "process": 61, "message": "Requested to assign parameter 'THOTH_ADVISER_DEV' (value '0') to template but template does not provide the given parameter, forcing..."}

Even though the variable is not in stage, didn't observe any issue as above.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>