### PR TITLE
Do not use OrderedDict for internal state representation

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -21,6 +21,7 @@ import gc
 import pytest
 from collections import OrderedDict
 import random
+import string
 
 from hypothesis import given
 from hypothesis.strategies import integers
@@ -196,3 +197,28 @@ class TestState(AdviserTestCase):
         """Test error out when random termial is used wih negative or zero value."""
         with pytest.raises(ValueError):
             State._random_termial(n)
+
+    @pytest.mark.parametrize("n", range(5))
+    def test_dict_order(self, n: int) -> None:
+        """Test relative insertion into dict preserves order.
+
+        This is an implementation detail for Python3.6 dict implementation and
+        requirement for Python 3.7. Make sure the running interpreter obeys
+        this.
+        """
+        items = []
+        seen = set()
+        for i in range(10):
+            key = "".join(random.choice(string.ascii_letters) for i in range(n))
+            if key in seen:
+                continue
+
+            seen.add(key)
+            items.append((key, i))
+
+        dict_ = dict(items)
+        assert list(dict_.items()) == items, "Order of items in dict is not preserved"
+
+        dict_["foo"] = 3003
+        assert list(dict_.items())[-1] == ("foo", 3003), "Last item added to dict is not last obtained"
+

--- a/thoth/adviser/state.py
+++ b/thoth/adviser/state.py
@@ -24,7 +24,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Generator
-from collections import OrderedDict
 import random
 import weakref
 
@@ -42,11 +41,11 @@ class State:
     iteration = attr.ib(type=int, default=0)
     # States added in the given iteration.
     unresolved_dependencies = attr.ib(
-        default=attr.Factory(OrderedDict)
-    )  # type: OrderedDict[str, OrderedDict[int, Tuple[str, str, str]]]
+        default=attr.Factory(dict)
+    )  # type: Dict[str, Dict[int, Tuple[str, str, str]]]
     resolved_dependencies = attr.ib(
-        default=attr.Factory(OrderedDict)
-    )  # type: OrderedDict[str, Tuple[str, str, str]]
+        default=attr.Factory(dict)
+    )  # type: Dict[str, Tuple[str, str, str]]
     advised_runtime_environment = attr.ib(
         type=Optional[RuntimeEnvironment], kw_only=True, default=None
     )
@@ -74,10 +73,10 @@ class State:
         cls, direct_dependencies: Dict[str, List[PackageVersion]]
     ) -> "State":
         """Create an initial state out of direct dependencies."""
-        unresolved_dependencies = OrderedDict()
+        unresolved_dependencies = {}
 
         for dependency_name, dependency_versions in direct_dependencies.items():
-            unresolved_dependencies[dependency_name] = OrderedDict()
+            unresolved_dependencies[dependency_name] = {}
             for dependency_version in dependency_versions:
                 dependency_tuple = dependency_version.to_tuple()
                 unresolved_dependencies[dependency_name][
@@ -117,7 +116,7 @@ class State:
     def add_unresolved_dependency(self, package_tuple: Tuple[str, str, str]) -> None:
         """Add unresolved dependency into the state."""
         if package_tuple[0] not in self.unresolved_dependencies:
-            self.unresolved_dependencies[package_tuple[0]] = OrderedDict()
+            self.unresolved_dependencies[package_tuple[0]] = {}
 
         self.unresolved_dependencies[package_tuple[0]][
             hash(package_tuple)
@@ -128,8 +127,8 @@ class State:
     ) -> None:
         """Set unresolved dependencies - any unresolved dependencies will be overwritten."""
         for dependency_name, dependency_tuples in dependencies.items():
-            self.unresolved_dependencies[dependency_name] = OrderedDict(
-                [(hash(d), d) for d in dependency_tuples]
+            self.unresolved_dependencies[dependency_name] = dict(
+                (hash(d), d) for d in dependency_tuples
             )
 
     def remove_unresolved_dependency(self, package_tuple: Tuple[str, str, str]) -> None:
@@ -304,9 +303,9 @@ class State:
                 self.advised_runtime_environment.to_dict()
             )
 
-        unresolved_dependencies = OrderedDict(self.unresolved_dependencies)
+        unresolved_dependencies = dict(self.unresolved_dependencies)
         for dependency_name in unresolved_dependencies.keys():
-            unresolved_dependencies[dependency_name] = OrderedDict(
+            unresolved_dependencies[dependency_name] = dict(
                 unresolved_dependencies[dependency_name]
             )
 
@@ -314,7 +313,7 @@ class State:
             score=self.score,
             iteration=self.iteration,
             unresolved_dependencies=unresolved_dependencies,
-            resolved_dependencies=OrderedDict(self.resolved_dependencies),
+            resolved_dependencies=dict(self.resolved_dependencies),
             advised_runtime_environment=cloned_advised_environment,
             justification=list(self.justification),
             parent=weakref.ref(self),


### PR DESCRIPTION
OrderedDict requires additinal data structures to offer some of the OrderedDict
functionality on top of dict we do not use. Let's rely on Python 3.6
implementation detail that dict is ordered - this will follow more recent Python
implementations (starting Python 3.7 dict is ordered by default).

This simple change saves roughly 36% of memory when computing recommendations
for "tensorflow==*".