### PR TITLE
Disable setup.py processing in s2i builds

### DIFF
--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -84,6 +84,8 @@ objects:
               value: "1"
             - name: UPGRADE_PIP_TO_LATEST
               value: ""
+            - name: DISABLE_SETUP_PY_PROCESSING
+              value: "1"
             - name: "THOTH_DRY_RUN"
               value: "0"
             - name: "THOTH_ADVISE"


### PR DESCRIPTION
See https://github.com/sclorg/s2i-python-container/tree/master/3.6#environment-variables for more info.