### PR TITLE
Introduce a sieve to filter out incompatible setuptools for Python 3.6

### DIFF
--- a/tests/sieves/test_py36_setuptools.py
+++ b/tests/sieves/test_py36_setuptools.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2020 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test sieve to filter out old setuptools that do not work with Python 3.6."""
+
+from typing import Optional
+
+import flexmock
+import pytest
+
+from thoth.adviser.enums import DecisionType
+from thoth.adviser.enums import RecommendationType
+from thoth.adviser.pipeline_builder import PipelineBuilderContext
+from thoth.adviser.sieves import Py36SetuptoolsSieve
+from thoth.python import PackageVersion
+from thoth.python import Source
+
+from ..base import AdviserTestCase
+
+
+class TestPy36SetuptoolsSieve(AdviserTestCase):
+    """Test sieve to filter out old setuptools that do not work with Python 3.6."""
+
+    @pytest.mark.parametrize(
+        "recommendation_type,decision_type",
+        [
+            (RecommendationType.STABLE, None),
+            (RecommendationType.TESTING, None),
+            (None, DecisionType.RANDOM),
+            (None, DecisionType.ALL),
+        ],
+    )
+    def test_include(
+        self,
+        builder_context: PipelineBuilderContext,
+        recommendation_type: RecommendationType,
+        decision_type: DecisionType,
+    ) -> None:
+        """Test including this pipeline unit."""
+        builder_context.decision_type = decision_type
+        builder_context.recommendation_type = recommendation_type
+        builder_context.project.runtime_environment.python_version = "3.6"
+
+        assert builder_context.is_adviser_pipeline() or builder_context.is_dependency_monkey_pipeline()
+        assert Py36SetuptoolsSieve.should_include(builder_context) == {}
+
+    @pytest.mark.parametrize(
+        "recommendation_type,decision_type,python_version",
+        [
+            (RecommendationType.STABLE, None, "3.8"),
+            (RecommendationType.TESTING, None, "3.9"),
+            (None, DecisionType.RANDOM, "3.5"),
+        ],
+    )
+    def test_no_include(
+        self,
+        builder_context: PipelineBuilderContext,
+        recommendation_type: RecommendationType,
+        decision_type: DecisionType,
+        python_version: str,
+    ) -> None:
+        """Test not including this pipeline unit step."""
+        builder_context.decision_type = decision_type
+        builder_context.recommendation_type = recommendation_type
+        builder_context.project.runtime_environment.python_version = python_version
+        assert Py36SetuptoolsSieve.should_include(builder_context) is None
+
+    def test_filter(self) -> None:
+        """Test filtering out setuptools that do not work with Python 3.6."""
+        package_version = PackageVersion(
+            name="setuptools",
+            version="==14.2",
+            develop=False,
+            index=Source("https://pypi.org/simple"),
+        )
+
+        context = flexmock()
+        with Py36SetuptoolsSieve.assigned_context(context):
+            unit = Py36SetuptoolsSieve()
+            assert list(unit.run(p for p in [package_version])) == []
+
+    def test_no_filter(self) -> None:
+        """Test not filtering packages that can be included."""
+        pkg1 = PackageVersion(
+            name="setuptools",
+            version="==17.0",
+            develop=False,
+            index=Source("https://pypi.org/simple"),
+        )
+        pkg2 = PackageVersion(
+            name="setuptools",
+            version="==49.1.0",
+            develop=False,
+            index=Source("https://pypi.org/simple"),
+        )
+        pkg3 = PackageVersion(
+            name="tensorflow",
+            version="==2.2.0",
+            develop=False,
+            index=Source("https://thoth-station.ninja/simple"),
+        )
+
+        pkgs = [pkg1, pkg2, pkg3]
+
+        context = flexmock()
+        with Py36SetuptoolsSieve.assigned_context(context):
+            unit = Py36SetuptoolsSieve()
+            assert list(unit.run(p for p in pkgs)) == pkgs

--- a/thoth/adviser/sieves/__init__.py
+++ b/thoth/adviser/sieves/__init__.py
@@ -18,10 +18,11 @@
 """Implementation of sieves used in adviser pipeline."""
 
 from .abi_compat import AbiCompatibilitySieve
+from .filter_index import FilterIndexSieve
 from .index_enabled import PackageIndexSieve
 from .locked import CutLockedSieve
-from .filter_index import FilterIndexSieve
 from .prereleases import CutPreReleasesSieve
+from .py36_setuptools import Py36SetuptoolsSieve
 from .solved import SolvedSieve
 from .version_constraint import VersionConstraintSieve
 
@@ -32,6 +33,7 @@ from .version_constraint import VersionConstraintSieve
 __all__ = [
     "CutLockedSieve",
     "CutPreReleasesSieve",
+    "Py36SetuptoolsSieve",
     "PackageIndexSieve",
     "SolvedSieve",
     "VersionConstraintSieve",

--- a/thoth/adviser/sieves/py36_setuptools.py
+++ b/thoth/adviser/sieves/py36_setuptools.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2020 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""A sieve to filter out old setuptools that do not work with Python 3.6."""
+
+import logging
+from typing import Optional
+from typing import Dict
+from typing import Any
+from typing import Generator
+from typing import TYPE_CHECKING
+
+import attr
+from thoth.python import PackageVersion
+
+from ..sieve import Sieve
+
+if TYPE_CHECKING:
+    from ..pipeline_builder import PipelineBuilderContext
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@attr.s(slots=True)
+class Py36SetuptoolsSieve(Sieve):
+    """Filter out old setuptools that do not work with Python 3.6.
+
+    https://github.com/pypa/setuptools/issues/378
+    https://github.com/thoth-station/solver/issues/350
+    """
+
+    @classmethod
+    def should_include(
+        cls, builder_context: "PipelineBuilderContext"
+    ) -> Optional[Dict[str, Any]]:
+        """Include for Python 3.6 and adviser/dependency monkey runs."""
+        if builder_context.is_included(cls):
+            return None
+
+        if builder_context.project.runtime_environment.python_version == "3.6":
+            return {}
+
+        return None
+
+    def run(
+        self, package_versions: Generator[PackageVersion, None, None]
+    ) -> Generator[PackageVersion, None, None]:
+        """Filter out old setuptools that do not work with Python 3.6"""
+        for package_version in package_versions:
+            if package_version.name != "setuptools" or package_version.semantic_version.major >= 17:
+                yield package_version


### PR DESCRIPTION
Fixes: https://github.com/thoth-station/solver/issues/350