### PR TITLE
Introduce a stride for discarding non-unique stacks

### DIFF
--- a/tests/strides/test_unique_stack.py
+++ b/tests/strides/test_unique_stack.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2020 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test filtering duplicate stacks."""
+
+from flexmock import flexmock
+import pytest
+
+from thoth.adviser.enums import DecisionType
+from thoth.adviser.enums import RecommendationType
+from thoth.adviser.exceptions import NotAcceptable
+from thoth.adviser.state import State
+from thoth.adviser.strides import UniqueStackStride
+from thoth.adviser.pipeline_builder import PipelineBuilderContext
+
+from ..base import AdviserTestCase
+
+
+class TestUniqueStackStride(AdviserTestCase):
+    """Test filtering duplicate stacks."""
+
+    @pytest.mark.parametrize(
+        "recommendation_type,decision_type",
+        [*((v, None) for v in RecommendationType.__members__), *((None, d) for d in DecisionType.__members__),],
+    )
+    def test_should_include(
+        self,
+        builder_context: PipelineBuilderContext,
+        recommendation_type: RecommendationType,
+        decision_type: DecisionType,
+    ) -> None:
+        """Test no inclusion of this pipeline unit."""
+        builder_context.decision_type = decision_type
+        builder_context.recommendation_type = recommendation_type
+        assert builder_context.is_adviser_pipeline() or builder_context.is_dependency_monkey_pipeline()
+        assert UniqueStackStride.should_include(builder_context) is None
+
+    def test_run(self) -> None:
+        """Test running this stride to filter same stacks."""
+        context = flexmock()
+
+        state = State()
+        state.add_resolved_dependency(("tensorflow", "2.2.0", "https://pypi.org/simple"))
+
+        unit = UniqueStackStride()
+        with unit.assigned_context(context):
+            assert unit.run(state) is None
+
+            # Running the stride on the same stack should cause rejecting it.
+            with pytest.raises(NotAcceptable):
+                unit.run(state)
+
+            # A stack with another package should be included.
+            state.add_resolved_dependency(("numpy", "1.19.1", "https://pypi.org/simple"))
+            assert unit.run(state) is None

--- a/thoth/adviser/strides/__init__.py
+++ b/thoth/adviser/strides/__init__.py
@@ -17,14 +17,16 @@
 
 """Implementation of strides used to filter out resolved stacks."""
 
-from .random_decision import RandomDecisionStride
 from .one_version import OneVersionStride
+from .random_decision import RandomDecisionStride
+from .unique_stack import UniqueStackStride
 
 
 # Relative ordering of units is relevant, as the order specifies order
 # in which the asked to be registered - any dependencies between them
 # can be mentioned here.
 __all__ = [
-    "RandomDecisionStride",
     "OneVersionStride",
+    "RandomDecisionStride",
+    "UniqueStackStride",
 ]

--- a/thoth/adviser/strides/unique_stack.py
+++ b/thoth/adviser/strides/unique_stack.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2020 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Filter out software stacks that were already resolved.
+
+This pipeline unit is especially useful for dependency monkey runs when no
+duplicate software stacks should be resolved.
+"""
+
+import logging
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+from typing import Set
+from typing import FrozenSet
+from typing import TYPE_CHECKING
+
+import attr
+
+from ..state import State
+from ..stride import Stride
+from ..exceptions import NotAcceptable
+
+if TYPE_CHECKING:
+    from ..pipeline_builder import PipelineBuilderContext
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@attr.s(slots=True)
+class UniqueStackStride(Stride):
+    """Filter out software stacks that were already resolved.
+
+    As dependency graphs can share nodes, it might happen that the same
+    software stack can be resolved multiple times considering different
+    resolution paths.
+    """
+
+    stacks_seen = attr.ib(type=Set[FrozenSet[Tuple[str, str, str]]], default=attr.Factory(set), init=False)
+
+    @classmethod
+    def should_include(cls, builder_context: "PipelineBuilderContext") -> Optional[Dict[str, Any]]:
+        """Include this pipeline unit only if user asks for it explicitly."""
+        return None
+
+    def pre_run(self) -> None:
+        """Initialize internal state of the unit."""
+        self.stacks_seen.clear()
+
+    def run(self, state: State) -> None:
+        """Filter out software stacks that were already resolved."""
+        stack = frozenset(state.resolved_dependencies.values())
+        if stack not in self.stacks_seen:
+            self.stacks_seen.add(stack)
+        else:
+            raise NotAcceptable


### PR DESCRIPTION
This pipeline unit is especially useful for dependency monkey runs when no duplicate software stacks should be resolved in the same dependency monkey run.

## This introduces a breaking change

- [x] No
