### PR TITLE
Fix detection of OOM when os.waitpid is used

### DIFF
--- a/thoth/adviser/run.py
+++ b/thoth/adviser/run.py
@@ -132,7 +132,7 @@ def subprocess_run(
         _, exit_code = os.waitpid(pid, 0)
         if exit_code != 0:
             _LOGGER.error("Child exited with exit code %r", exit_code)
-            if exit_code == 9 or exit_code == 137:
+            if (exit_code & 0xF) == 9:
                 err_msg = "Adviser was killed as allocated memory has been exceeded (OOM)"
             elif os.path.isfile(_LIVENESS_PROBE_KILL_FILE):
                 err_msg = "Adviser was killed as allocated CPU time was exceeded"


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/adviser/issues/1128

## This introduces a breaking change

- [x] No

## Description

> exit status indication: a 16-bit number, whose low byte is the signal number that killed the process, and whose high byte is the exit status (if the signal number is zero)

https://docs.python.org/3/library/os.html#os.wait