### PR TITLE
Fix SI step inclusion

### DIFF
--- a/thoth/adviser/steps/security_indicators.py
+++ b/thoth/adviser/steps/security_indicators.py
@@ -59,10 +59,10 @@ class SecurityIndicatorStep(Step):
         if (
             builder_context.recommendation_type == RecommendationType.SECURITY
             or builder_context.recommendation_type == RecommendationType.STABLE
-        ):
+        ) and not builder_context.is_included(cls):
             return {}
-        else:
-            return None
+
+        return None
 
     @staticmethod
     def _generate_justification(name: str, version: str, index: str) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

Fixes: https://github.com/thoth-station/adviser/issues/1145

## Description

Pipeline units can be included multiple times. For the SI pipeline unit, there was missing check if the pipeline unit is already included. This caused that adviser was trying to include this pipeline unit on each interation when building the resolution pipeline.