### PR TITLE
Apply limit of stacks only for the accepted stacks

### DIFF
--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -968,11 +968,10 @@ class Resolver:
         self.stop_resolving = False
         with _sigint_handler(self):
             while not self.stop_resolving:
-                if self.context.accepted_final_states_count + self.context.discarded_final_states_count >= self.limit:
+                if self.context.accepted_final_states_count >= self.limit:
                     _LOGGER.info(
-                        "Reached limit of stacks to be generated - %r (limit is %r), stopping resolver "
+                        "Reached limit of stacks to be generated (limit is %r), stopping resolver "
                         "with the current beam size %d in iteration %d",
-                        self.context.accepted_final_states_count,
                         self.limit,
                         self.beam.size,
                         self.context.iteration,


### PR DESCRIPTION
Counting discarded stacks to the limit is not intuitive to the user. This way
user can say "generate N stacks during dependency monkey run" and let the
resolver do its job.

## This introduces a breaking change

- [x] No
