### PR TITLE
Correct messages printed to users

### DIFF
--- a/thoth/adviser/run.py
+++ b/thoth/adviser/run.py
@@ -135,9 +135,9 @@ def subprocess_run(
         if exit_code != 0:
             _LOGGER.error("Child exited with exit code %r", exit_code)
             if (exit_code & 0xF) == 9:
-                err_msg = f"Adviser was killed as allocated memory has been exceeded (OOM) - {jl('oom')}"
+                err_msg = f"Resolver was killed as allocated memory has been exceeded (OOM) - {jl('oom')}"
             elif os.path.isfile(_LIVENESS_PROBE_KILL_FILE):
-                err_msg = f"Adviser was killed as allocated CPU time was exceeded - {jl('cpu_time_exceeded')}"
+                err_msg = f"Resolver was killed as allocated CPU time was exceeded - {jl('cpu_time_exceeded')}"
             else:
                 err_msg = (
                     f"Resolution was terminated based on errors encountered; "


### PR DESCRIPTION
These messages correspond to the resolution process, not to adviser
specifically.

## This introduces a breaking change

- [x] No
