### PR TITLE
Notify users about accuracy bug when TensorFlow 2.3 is used

### DIFF
--- a/tests/wraps/test_tf_accuracy.py
+++ b/tests/wraps/test_tf_accuracy.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2020 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test wrap that notifies about accuracy bug on safe()/load_model() calls."""
+
+import pytest
+
+from thoth.adviser.state import State
+from thoth.adviser.wraps import TensorFlow23Accuracy
+
+from ..base import AdviserTestCase
+
+
+class TestTensorFlow23Accuracy(AdviserTestCase):
+    """Test wrap that notifies about accuracy bug on safe()/load_model() calls."""
+
+    def test_run_noop(self) -> None:
+        """Test no justification added if TensorFlow 2.3 is not resolved."""
+        state = State()
+        assert not state.justification
+        assert "tensorflow" not in state.resolved_dependencies
+
+        state.add_resolved_dependency(("tensorflow", "2.2.0", "https://pypi.org/simple"))
+
+        unit = TensorFlow23Accuracy()
+        unit.run(state)
+
+        assert len(state.justification) == 0
+
+    @pytest.mark.parametrize("tf_version", ["2.3.0"])
+    def test_run(self, tf_version: str) -> None:
+        """Test adding justification added if TensorFlow 2.3 is not resolved."""
+        state = State()
+        assert not state.justification
+        assert "tensorflow" not in state.resolved_dependencies
+
+        state.add_resolved_dependency(("tensorflow", tf_version, "https://pypi.org/simple"))
+
+        unit = TensorFlow23Accuracy()
+        unit.run(state)
+
+        assert len(state.justification) == 1
+        assert set(state.justification[0].keys()) == {"type", "message", "link"}
+        assert state.justification[0]["type"] == "WARNING"
+        assert state.justification[0]["message"], "No justification message provided"
+        assert state.justification[0]["link"], "Empty link to justification document provided"

--- a/thoth/adviser/wraps/__init__.py
+++ b/thoth/adviser/wraps/__init__.py
@@ -21,6 +21,7 @@ from .mkl_threads import MKLThreadsWrap
 from .no_onservation import NoObservationWrap
 from .no_semantic_interposition import NoSemanticInterpositionWrap
 from .intel_tensorflow import IntelTensorFlowWrap
+from .tf_accuracy import TensorFlow23Accuracy
 
 
 # Relative ordering of units is relevant, as the order specifies order
@@ -31,4 +32,5 @@ __all__ = [
     "NoObservationWrap",
     "NoSemanticInterpositionWrap",
     "IntelTensorFlowWrap",
+    "TensorFlow23Accuracy",
 ]

--- a/thoth/adviser/wraps/tf_accuracy.py
+++ b/thoth/adviser/wraps/tf_accuracy.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2020 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""A wrap that notifies about accuracy bug on safe()/load_model() calls."""
+
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import TYPE_CHECKING
+
+from thoth.common import get_justification_link as jl
+
+from ..state import State
+from ..wrap import Wrap
+
+if TYPE_CHECKING:
+    from ..pipeline_builder import PipelineBuilderContext
+
+
+class TensorFlow23Accuracy(Wrap):
+    """A wrap that notifies about accuracy bug on safe()/load_model() calls.
+
+    https://github.com/tensorflow/tensorflow/issues/42045
+    https://github.com/keras-team/keras/issues/14181
+    https://github.com/tensorflow/tensorflow/commit/5adacc88077ef82f6c4a7f9bb65f9ed89f9d8947
+    """
+
+    _JUSTIFICATION = [
+        {
+            "type": "WARNING",
+            "message": "TensorFlow in version 2.3 produces wrong model accuracy when the model is "
+                       "serialized using `accuracy`, use `sparse_categorical_accuracy` instead",
+            "link": jl("tf_42045"),
+        }
+    ]
+
+    @classmethod
+    def should_include(cls, builder_context: "PipelineBuilderContext") -> Optional[Dict[str, Any]]:
+        """Include this wrap in adviser."""
+        if builder_context.is_included(cls) or not builder_context.is_adviser_pipeline():
+            return None
+
+        return {}
+
+    def run(self, state: State) -> None:
+        """Notify about accuracy bug in safe()/load_model() calls."""
+        if "tensorflow" in state.resolved_dependencies and state.resolved_dependencies["tensorflow"][1][:3] == "2.3":
+            state.add_justification(self._JUSTIFICATION)


### PR DESCRIPTION
See https://github.com/tensorflow/tensorflow/issues/42045

## Related issues

https://github.com/thoth-station/thoth-station.github.io/pull/132

## This introduces a breaking change

- [x] No
