### PR TITLE
include whiskey_lake microarch to list of avx2 containing archs

### DIFF
--- a/thoth/adviser/steps/tensorflow_avx2.py
+++ b/thoth/adviser/steps/tensorflow_avx2.py
@@ -64,7 +64,7 @@ class TensorFlowAVX2Step(Step):
             (0x6, 0xA),  # Ice Lake
             (0x6, 0xC),  # Ice Lake, Tiger Lake
             (0x6, 0xD),  # Ice Lake
-            (0x6, 0xE),  # Skylake, Keby Lake, Coffee Lake, Ice Lake, Comet Lake
+            (0x6, 0xE),  # Skylake, Kaby Lake, Coffee Lake, Ice Lake, Comet Lake, Whiskey Lake
             (0x6, 0xF),  # Haswell
         }
     )


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #1022 

## This introduces a breaking change

- [x] No

## This Pull Request implements

- update whiskey lake to the list.

## Description

include whiskey_lake micro arch to list of avx2 containing archs
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
