### PR TITLE
Introduce a step for removing scipy for TF>=2.1<2.3 releases

### DIFF
--- a/tests/steps/tensorflow/test_tf_rm_scipy.py
+++ b/tests/steps/tensorflow/test_tf_rm_scipy.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2020 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test removing SciPy from a TensorFlow>=2.1<2.3 stack."""
+
+from itertools import product
+
+import pytest
+
+from thoth.adviser.context import Context
+from thoth.adviser.enums import DecisionType
+from thoth.adviser.enums import RecommendationType
+from thoth.adviser.pipeline_builder import PipelineBuilderContext
+from thoth.adviser.state import State
+from thoth.adviser.steps import TensorFlowRemoveSciPyStep
+from thoth.adviser.exceptions import SkipPackage
+from thoth.python import PackageVersion
+from thoth.python import Source
+
+from ...base import AdviserTestCase
+
+
+class TestTensorFlowRemoveSciPyStep(AdviserTestCase):
+    """Test related to removing SciPy from a TensorFlow>=2.1<2.3 stack."""
+
+    @pytest.mark.parametrize(
+        "recommendation_type", [RecommendationType.STABLE, RecommendationType.PERFORMANCE, RecommendationType.SECURITY]
+    )
+    def test_include(self, builder_context: PipelineBuilderContext, recommendation_type: RecommendationType) -> None:
+        """Test including this pipeline unit."""
+        builder_context.decision_type = None
+        builder_context.recommendation_type = recommendation_type
+        assert "scipy" not in builder_context.project.pipfile.packages
+        assert builder_context.is_adviser_pipeline()
+        assert TensorFlowRemoveSciPyStep.should_include(builder_context) == {}
+
+    @pytest.mark.parametrize(
+        "recommendation_type,decision_type,add_direct_scipy",
+        [
+            (RecommendationType.LATEST, None, False),
+            (RecommendationType.TESTING, None, False),
+            (RecommendationType.STABLE, None, True),
+            (None, DecisionType.RANDOM, False),
+        ],
+    )
+    def test_no_include(
+        self,
+        builder_context: PipelineBuilderContext,
+        recommendation_type: RecommendationType,
+        decision_type: DecisionType,
+        add_direct_scipy: bool,
+    ) -> None:
+        """Test not including this pipeline unit step."""
+        builder_context.decision_type = decision_type
+        builder_context.recommendation_type = recommendation_type
+
+        if add_direct_scipy:
+            builder_context.project.add_package(package_name="scipy", package_version="==1.2.2", develop=False)
+            assert "scipy" in builder_context.project.pipfile.packages.packages
+
+        assert TensorFlowRemoveSciPyStep.should_include(builder_context) is None
+
+    @pytest.mark.parametrize(
+        "tf_name,tf_version",
+        [
+            *product(
+                ["tensorflow", "tensorflow-cpu", "tensorflow-gpu", "intel-tensorflow"],
+                ["2.1.0", "2.1.1", "2.2.0rc0", "2.2.0"],
+            )
+        ],
+    )
+    def test_run_skip_package(self, context: Context, state: State, tf_name: str, tf_version: str) -> None:
+        """Test removing scipy from a TensorFlow stack."""
+        scipy_package_version = PackageVersion(
+            name="scipy", version="==1.2.2", develop=False, index=Source("https://pypi.org/simple"),
+        )
+        tf_package_version = PackageVersion(
+            name=tf_name, version=f"=={tf_version}", develop=False, index=Source("https://pypi.org/simple"),
+        )
+
+        assert "tensorflow" not in state.resolved_dependencies
+        state.resolved_dependencies["tensorflow"] = tf_package_version.to_tuple()
+        context.register_package_version(tf_package_version)
+        context.dependents["scipy"] = {
+            scipy_package_version.to_tuple(): {(tf_package_version.to_tuple(), "rhel", "8", "3.6")}
+        }
+
+        with TensorFlowRemoveSciPyStep.assigned_context(context):
+            unit = TensorFlowRemoveSciPyStep()
+            with pytest.raises(SkipPackage):
+                unit.run(state, scipy_package_version)
+
+    @pytest.mark.parametrize(
+        "tf_name,tf_version",
+        [
+            *product(
+                ["tensorflow", "tensorflow-cpu", "tensorflow-gpu", "intel-tensorflow"],
+                ["2.0.0", "1.9.1", "1.15.3", "2.3.0"],
+            )
+        ],
+    )
+    def test_run_noop(self, context: Context, state: State, tf_name: str, tf_version: str) -> None:
+        """Test not removing scipy from a TensorFlow stack."""
+        scipy_package_version = PackageVersion(
+            name="scipy", version="==1.2.2", develop=False, index=Source("https://pypi.org/simple"),
+        )
+        tf_package_version = PackageVersion(
+            name=tf_name, version=f"=={tf_version}", develop=False, index=Source("https://pypi.org/simple"),
+        )
+
+        assert "tensorflow" not in state.resolved_dependencies
+        state.resolved_dependencies["tensorflow"] = tf_package_version.to_tuple()
+        context.register_package_version(tf_package_version)
+        context.dependents["scipy"] = {
+            scipy_package_version.to_tuple(): {(tf_package_version.to_tuple(), "rhel", "8", "3.6")}
+        }
+
+        unit = TensorFlowRemoveSciPyStep()
+        with TensorFlowRemoveSciPyStep.assigned_context(context):
+            assert unit.run(state, scipy_package_version) is None
+
+    def test_run_deps(self, context: Context, state: State) -> None:
+        """Test not removing scipy from a TensorFlow stack if introduced by another dependency."""
+        scipy_package_version = PackageVersion(
+            name="scipy", version="==1.2.2", develop=False, index=Source("https://pypi.org/simple"),
+        )
+        tf_package_version = PackageVersion(
+            name="tensorflow", version="==2.2.0", develop=False, index=Source("https://pypi.org/simple"),
+        )
+        another_package_version = PackageVersion(
+            name="some-package", version="==1.0.0", develop=False, index=Source("https://pypi.org/simple"),
+        )
+
+        assert "tensorflow" not in state.resolved_dependencies
+        state.resolved_dependencies["tensorflow"] = tf_package_version.to_tuple()
+        state.resolved_dependencies[another_package_version.name] = another_package_version.to_tuple()
+        context.register_package_version(tf_package_version)
+        context.dependents["scipy"] = {
+            scipy_package_version.to_tuple(): {
+                (tf_package_version.to_tuple(), "rhel", "8", "3.6"),
+                (another_package_version.to_tuple(), "rhel", "8", "3.6"),
+            }
+        }
+
+        unit = TensorFlowRemoveSciPyStep()
+        with TensorFlowRemoveSciPyStep.assigned_context(context):
+            assert unit.run(state, scipy_package_version) is None

--- a/thoth/adviser/steps/__init__.py
+++ b/thoth/adviser/steps/__init__.py
@@ -27,6 +27,7 @@ from .tensorflow import TensorFlowAVX2Step
 from .tensorflow import TensorFlow113NumPyStep
 from .tensorflow import TensorFlow114GastStep
 from .tensorflow import TensorFlow22NumPyStep
+from .tensorflow import TensorFlowRemoveSciPyStep
 
 # from ._debug import MockScoreStep
 
@@ -46,4 +47,5 @@ __all__ = [
     "TensorFlow113NumPyStep",
     "TensorFlow114GastStep",
     "TensorFlow22NumPyStep",
+    "TensorFlowRemoveSciPyStep",
 ]

--- a/thoth/adviser/steps/tensorflow/__init__.py
+++ b/thoth/adviser/steps/tensorflow/__init__.py
@@ -23,6 +23,7 @@ from .tf_avx2 import TensorFlowAVX2Step
 from .tf_113_numpy import TensorFlow113NumPyStep
 from .tf_114_gast import TensorFlow114GastStep
 from .tf_22_numpy import TensorFlow22NumPyStep
+from .tf_rm_scipy import TensorFlowRemoveSciPyStep
 
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "TensorFlow113NumPyStep",
     "TensorFlow114GastStep",
     "TensorFlow22NumPyStep",
+    "TensorFlowRemoveSciPyStep",
 ]

--- a/thoth/adviser/steps/tensorflow/tf_rm_scipy.py
+++ b/thoth/adviser/steps/tensorflow/tf_rm_scipy.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2020 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""A step that removes SciPy dependency from the dependency listing for TensorFlow>=2.1<=2.3."""
+
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import TYPE_CHECKING
+
+import logging
+
+import attr
+from thoth.common import get_justification_link as jl
+from thoth.python import PackageVersion
+
+from ...enums import RecommendationType
+from ...exceptions import SkipPackage
+from ...state import State
+from ...step import Step
+
+if TYPE_CHECKING:
+    from ..pipeline_builder import PipelineBuilderContext
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@attr.s(slots=True)
+class TensorFlowRemoveSciPyStep(Step):
+    """A step that removes SciPy dependency from a TensorFlow>2.1<=2.3 stack.
+
+    https://github.com/tensorflow/tensorflow/pull/41866
+    https://github.com/tensorflow/tensorflow/issues/40884
+    https://github.com/tensorflow/tensorflow/issues/35709
+    https://github.com/tensorflow/tensorflow/issues/41941
+    https://github.com/tensorflow/tensorflow/pull/40789
+    """
+
+    _message_logged = attr.ib(type=bool, default=False, init=False)
+
+    _MESSAGE = (
+        f"TensorFlow in versions >=2.1<=2.3 stated SciPy as a dependency but it is "
+        f"not used in the codebase - see {jl('tf_rm_scipy')}"
+    )
+
+    _RECOMMENDATION_TYPES = {RecommendationType.LATEST, RecommendationType.TESTING}
+
+    @classmethod
+    def should_include(cls, builder_context: "PipelineBuilderContext") -> Optional[Dict[Any, Any]]:
+        """Include this unit in adviser, except for latest recommendations."""
+        if (
+            not builder_context.is_adviser_pipeline()
+            or builder_context.recommendation_type in cls._RECOMMENDATION_TYPES
+        ):
+            return None
+
+        if "scipy" in builder_context.project.pipfile.packages.packages:
+            # scipy is a direct dependency, it should be always present in the stack.
+            return None
+
+        if not builder_context.is_included(cls):
+            return {}
+
+        return None
+
+    def pre_run(self) -> None:
+        """Initialize this pipeline unit before each run."""
+        self._message_logged = False
+
+    def run(
+        self, state: State, package_version: PackageVersion
+    ) -> Optional[Tuple[Optional[float], Optional[List[Dict[str, str]]]]]:
+        """Remove SciPy dependency from a TensorFlow>2.1<=2.3 stack."""
+        if package_version.name != "scipy":
+            return None
+
+        tensorflow_any = (
+            state.resolved_dependencies.get("tensorflow")
+            or state.resolved_dependencies.get("tensorflow-cpu")
+            or state.resolved_dependencies.get("tensorflow-gpu")
+        )
+
+        if not tensorflow_any:
+            return None
+
+        tf_package_version = self.context.get_package_version(tensorflow_any).semantic_version.release[:2]
+        if not tf_package_version or tf_package_version < (2, 1) or tf_package_version >= (2, 3):
+            return None
+
+        # Now check what package introduced the SciPy dependency. If it is solely TensorFlow, we can
+        # safely remove SciPy from dependencies.
+        scipy_dependents = {i[0] for i in self.context.dependents["scipy"][package_version.to_tuple()]}
+        introduced_by = scipy_dependents & set(state.resolved_dependencies.values())
+        if len(introduced_by) == 1 and next(iter(introduced_by)) == tensorflow_any:
+            if not self._message_logged:
+                _LOGGER.warning(self._MESSAGE)
+                self._message_logged = True
+
+            raise SkipPackage
+
+        return None


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/adviser/pull/1238
https://github.com/thoth-station/adviser/issues/1237
https://github.com/tensorflow/tensorflow/pull/41866
https://github.com/tensorflow/tensorflow/issues/40884
https://github.com/tensorflow/tensorflow/issues/35709
https://github.com/tensorflow/tensorflow/issues/41941
https://github.com/tensorflow/tensorflow/pull/4078

## This introduces a breaking change

- [x] No
