### PR TITLE
exclude hc hs if type is secure

### DIFF
--- a/tests/steps/test_security_indicators.py
+++ b/tests/steps/test_security_indicators.py
@@ -154,8 +154,7 @@ class TestSecurityIndicatorStep(AdviserUnitTestCase):
             "gathered information regarding security."
         )
 
-    @pytest.mark.parametrize("recommendation_type", [RecommendationType.SECURITY])
-    def test_security_indicator_with_high_high(self, recommendation_type) -> None:
+    def test_security_indicator_with_high_confidence(self) -> None:
         """Make sure we don't accept package if si info is missing when recommendation is secure."""
         flexmock(GraphDatabase)
         GraphDatabase.should_receive("get_si_aggregated_python_package_version").with_args(
@@ -167,7 +166,7 @@ class TestSecurityIndicatorStep(AdviserUnitTestCase):
         )
 
         context = flexmock(graph=GraphDatabase())
-        context.recommendation_type = recommendation_type
+        context.recommendation_type = RecommendationType.SECURITY
         with pytest.raises(NotAcceptable):
             with SecurityIndicatorStep.assigned_context(context):
                 step = SecurityIndicatorStep()

--- a/thoth/adviser/steps/security_indicators.py
+++ b/thoth/adviser/steps/security_indicators.py
@@ -97,9 +97,10 @@ class SecurityIndicatorStep(Step):
             index_url=package_version.index.url,
         )
 
+        package_version_tuple = package_version.to_tuple_locked()
+
         if s_info is None:
             if self.context.recommendation_type == RecommendationType.SECURITY:
-                package_version_tuple = package_version.to_tuple_locked()
                 if package_version_tuple not in self._logged_packages:
                     self._logged_packages.add(package_version_tuple)
                     _LOGGER.warning(
@@ -115,6 +116,18 @@ class SecurityIndicatorStep(Step):
                     name=package_version.name, version=package_version.locked_version, index=package_version.index.url
                 ),
             )
+
+        if (
+            self.context.recommendation_type == RecommendationType.SECURITY
+            and s_info["severity_high_confidence_high"] != 0
+        ):
+            if package_version_tuple not in self._logged_packages:
+                self._logged_packages.add(package_version_tuple)
+                _LOGGER.warning(
+                    "Skipping including package %r because bandit found high security high confidence issue(s).",
+                    package_version_tuple,
+                )
+            raise NotAcceptable
 
         s_score = (
             (


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/adviser/issues/1410

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

We apply strict standards for security if user asks for secure stack, no high sev high confidence packages allowed.