### PR TITLE
Update docs to reflect package_name in boots, strides and wraps

### DIFF
--- a/docs/source/boots.rst
+++ b/docs/source/boots.rst
@@ -66,6 +66,20 @@ Real world examples
   * If a user uses hardware (CPU/GPU) that is not known to Thoth's knowledge
     base, a boot unit can halt adviser
 
+Triggering unit for a specific package
+======================================
+
+To help with scaling the recommendation engine when it comes to number of
+pipeline units possibly registered, it is a good practice to state to which
+package the given unit corresponds. To run the pipeline unit for a specific
+package, this fact should be reflected in the pipeline unit configuration by
+stating ``package_name`` configuration option. An example can be a pipeline
+unit specific for TensorFlow packages, which should state ``package_name:
+"tensorflow"`` in the pipeline configuration.
+
+If the pipeline unit is generic for any package, the ``package_name``
+configuration has to default to ``None``.
+
 Justifications in the recommended software stacks
 =================================================
 
@@ -86,6 +100,8 @@ An example implementation
 
   class ExampleBoot(Boot):
       """This is an example boot implementation."""
+
+    CONFIGURATION_DEFAULT: Dict[str, Any] = {"package_name": None}  # The pipeline unit is not specific to any package.
 
     def run(self) -> None:
         """Main entry-point for boot unit to demonstrate boot example."""

--- a/docs/source/pipeline.rst
+++ b/docs/source/pipeline.rst
@@ -138,7 +138,7 @@ whether inclusion of a package version is valid to a state - this is done for
 each and every package-version combination.
 
 If all the steps on a state accept the given package, a newly created state
-(this `corresponds to taking an action from a state to a new state in a Markov
+(this :ref:`corresponds to taking an action from a state to a new state in a Markov
 Decision Process <introduction_rl>`) is added to the resolver beam as a state
 to be considered during resolver run, respecting :ref:`beam width parameter
 <beam_width>`.
@@ -268,12 +268,11 @@ unit types - :ref:`boots <boots>`, :ref:`pseudonymns <pseudonyms>`,
 :ref:`sieves <sieves>`, :ref:`steps <steps>`, :ref:`strides <strides>` and
 :ref:`wraps <wraps>`.
 
-Moreover, pipeline units of type :ref:`sieves <sieves>` and :ref:`steps
-<steps>` can be specific to a package. This was introduced as an optimization
-to group these pipeline units based on packages they operate on not to call
-them ineffectively on packages that are not relevant in the resolution process.
-Note pipeline units can be called thousand times during the resolution process
-so this optimization matters a lot.
+Moreover, pipeline units can be specific to a package. This was introduced as
+an optimization to group these pipeline units based on packages they operate on
+not to call them ineffectively on packages that are not relevant in the
+resolution process.  Note pipeline units can be called thousand times during
+the resolution process so this optimization matters a lot.
 
 See implementation of :class:`PipelineBuilderContext
 <thoth.adviser.pipeline_builder.PipelineBuilderContext>` for more info on

--- a/docs/source/strides.rst
+++ b/docs/source/strides.rst
@@ -46,6 +46,20 @@ Real world examples
   <https://github.com/thoth-station/amun-api>`_ to gather observations about
   Python ecosystem and packages present
 
+Triggering unit for a specific package
+======================================
+
+To help with scaling the recommendation engine when it comes to number of
+pipeline units possibly registered, it is a good practice to state to which
+package the given unit corresponds. To run the pipeline unit for a specific
+package, this fact should be reflected in the pipeline unit configuration by
+stating ``package_name`` configuration option. An example can be a pipeline
+unit specific for TensorFlow packages, which should state ``package_name:
+"tensorflow"`` in the pipeline configuration.
+
+If the pipeline unit is generic for any package, the ``package_name``
+configuration has to default to ``None``.
+
 Justifications in the recommended software stacks
 =================================================
 
@@ -70,6 +84,8 @@ An example implementation
 
   class StrideExample(Stride):
       """Flip a coin, heads discard the given state."""
+
+      CONFIGURATION_DEFAULT: Dict[str, Any] = {"package_name": None}  # The pipeline unit is not specific to any package.
 
       def run(self, state: State) -> None:
           """The main entry-point for stride implementation demonstration."""

--- a/docs/source/unit.rst
+++ b/docs/source/unit.rst
@@ -55,8 +55,8 @@ configuration that should be applied to pipeline unit instance (an empty
 dictionary if no configuration changes are applied to the default pipeline
 configuration but the pipeline unit should be included in the pipeline
 configuration). The default configuration is provided by pipeline in a
-dictionary available as a class attribute in `Unit.CONFIGURATION_DEFAULT`. See
-:ref:`unit configuration section <unit_configuration>`.
+dictionary available as a class attribute in ``Unit.CONFIGURATION_DEFAULT``.
+See :ref:`unit configuration section <unit_configuration>`.
 
 The pipeline configuration creation is done in multiple rounds so
 :class:`PipelineBuilderContext
@@ -83,11 +83,10 @@ defined by providing :py:attr:`Unit.CONFIGURATION_SCHEMA
 configuration type - this schema is used to verify unit configuration
 correctness on unit instantiation.
 
-Note units of type :ref:`pseudonym <pseudonyms>`, :ref:`sieve <sieves>` and
-:ref:`step <steps>` have to provide "``package_name``" configuration in the
-configuration to state on which package they operate on. This configuration
-option can be ``None`` for :ref:`sieve <sieves>` and :ref:`step <steps>`
-pipeline units. See unit specific documentation for more info.
+Note units of type :ref:`pseudonym <pseudonyms>` and have to provide
+"``package_name``" configuration in the unit configuration to state on which
+package they operate on. Other pipeline units can default to ``None``. See unit
+specific documentation for more info.
 
 Pipeline unit configuration is then accessible via :func:`Unit.configuration
 <thoth.adviser.unit.Unit.configuration>` property on a unit instance which

--- a/docs/source/wraps.rst
+++ b/docs/source/wraps.rst
@@ -38,6 +38,20 @@ Real world examples
   some performance improvement
   <https://developers.redhat.com/blog/2020/06/25/red-hat-enterprise-linux-8-2-brings-faster-python-3-8-run-speeds/>`_.
 
+Triggering unit for a specific package
+======================================
+
+To help with scaling the recommendation engine when it comes to number of
+pipeline units possibly registered, it is a good practice to state to which
+package the given unit corresponds. To run the pipeline unit for a specific
+package, this fact should be reflected in the pipeline unit configuration by
+stating ``package_name`` configuration option. An example can be a pipeline
+unit specific for TensorFlow packages, which should state ``package_name:
+"tensorflow"`` in the pipeline configuration.
+
+If the pipeline unit is generic for any package, the ``package_name``
+configuration has to default to ``None``.
+
 Justifications in the recommended software stacks
 =================================================
 
@@ -63,6 +77,8 @@ An example implementation
 
   class NoSemanticInterpositionWrap(Wrap):
       """A wrap that recommends to switch to Python 3.8 on RHEL 8.2."""
+
+      CONFIGURATION_DEFAULT: Dict[str, Any] = {"package_name": None}  # The pipeline unit is not specific to any package.
 
       _JUSTIFICATION = [
         {
@@ -92,7 +108,7 @@ An example implementation
 
       def run(self, state: State) -> None:
           """Recommend using Python3.8 on RHEL/UBI 8.2."""
-          state.add_justification(self._JUSTIFICATION
+          state.add_justification(self._JUSTIFICATION)
 
 The implementation can also provide other methods, such as :func:`Unit.pre_run
 <thoth.adviser.unit.Unit.post_run>`, :func:`Unit.post_run


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
