### PR TITLE
Call wraps only if products are in the final resolver result

### DIFF
--- a/docs/source/wraps.rst
+++ b/docs/source/wraps.rst
@@ -7,6 +7,14 @@ The last pipeline unit type is named ":class:`wrap <thoth.adviser.wrap.Wrap>`".
 This pipeline unit is called after a final state is accepted by :ref:`strides
 <strides>`.
 
+.. note::
+
+  Based on internal optimizations done for faster resolution process, wraps do
+  not need to be called for all the states resolved and accepted by strides. If
+  a final state will not be considered as part of the pipeline result
+  respecting ``count`` parameter (number of software stacks returned based on
+  their score), wrap pipeline units are not called.
+
 The wrap pipeline unit can perform logic on already accepted final state. A
 possible use case for wrap pipeline unit can be addition of another
 justification based on the packages resolved. This is handy if you want to add

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -54,13 +54,13 @@ class TestReport(AdviserTestCase):
         report = Report(count=2, pipeline=pipeline_config)
 
         product1 = Product(project=None, score=0.42, justification=[], advised_runtime_environment=None)
-        report.add_product(product1)
+        assert report.add_product(product1) is True
         assert report.product_count() == 1
         assert list(report.iter_products()) == [product1]
         assert list(report.iter_products_sorted()) == [product1]
 
         product2 = Product(project=None, score=0.0, justification=[], advised_runtime_environment=None)
-        report.add_product(product2)
+        assert report.add_product(product2) is True
         assert report.product_count() == 2
         assert set(report.iter_products()) == {product1, product2}
         assert list(report.iter_products_sorted()) == [product1, product2]
@@ -68,7 +68,7 @@ class TestReport(AdviserTestCase):
         assert list(report.iter_products_sorted(reverse=False)) == [product2, product1]
 
         product3 = Product(project=None, score=0.98, justification=[], advised_runtime_environment=None)
-        report.add_product(product3)
+        assert report.add_product(product3) is True
         assert report.product_count() == 2
         assert set(report.iter_products()) == {product3, product1}
         assert list(report.iter_products_sorted()) == [product3, product1]
@@ -76,7 +76,15 @@ class TestReport(AdviserTestCase):
         assert list(report.iter_products_sorted(reverse=False)) == [product1, product3]
 
         product4 = Product(project=None, score=0.666, justification=[], advised_runtime_environment=None,)
-        report.add_product(product4)
+        assert report.add_product(product4) is True
+        assert report.product_count() == 2
+        assert set(report.iter_products()) == {product3, product4}
+        assert list(report.iter_products_sorted()) == [product3, product4]
+        assert list(report.iter_products_sorted(reverse=True)) == [product3, product4]
+        assert list(report.iter_products_sorted(reverse=False)) == [product4, product3]
+
+        product5 = Product(project=None, score=-0.99999, justification=[], advised_runtime_environment=None,)
+        assert report.add_product(product5) is False
         assert report.product_count() == 2
         assert set(report.iter_products()) == {product3, product4}
         assert list(report.iter_products_sorted()) == [product3, product4]

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1373,7 +1373,8 @@ class TestResolver(AdviserTestCase):
             stride.should_receive("run").with_args(final_state).and_return(None).once()
 
         for wrap in resolver.pipeline.wraps:
-            wrap.should_receive("run").with_args(final_state).and_return(None).once()
+            # Optimization of the wraps call causes no wrap is called in the raw part.
+            wrap.should_receive("run").with_args(final_state).and_return(None).times(0)
 
         resolver.should_receive("_prepare_initial_state").with_args(with_devel=True).and_return(final_state).once()
 
@@ -1390,7 +1391,7 @@ class TestResolver(AdviserTestCase):
             final_state
         ).once()
 
-        states = list(resolver._do_resolve_states_raw(with_devel=True, user_stack_scoring=True))
+        states = list(resolver._do_resolve_states_raw(with_devel=True, user_stack_scoring=False))
         assert states == [final_state]
         assert resolver.context.iteration == 2
         assert resolver.context.accepted_final_states_count == 1
@@ -1590,9 +1591,13 @@ class TestResolver(AdviserTestCase):
 
     def test_resolve(self, resolver: Resolver) -> None:
         """Test report creation during resolution."""
-        product = flexmock(score=1.0)
+        state = State()
+        state.unresolved_dependencies.clear()
+        state.score = 1.0
+        assert state.is_final()
+
         resolver.should_receive("_do_resolve_states").with_args(with_devel=True, user_stack_scoring=True).and_return(
-            [product]
+            [state]
         ).once()
         resolver.pipeline.should_receive("call_post_run_report").once()
         resolver.predictor.should_receive("post_run_report").once()
@@ -1604,7 +1609,8 @@ class TestResolver(AdviserTestCase):
 
         assert resolver.context is not None, "Context is not bound to resolver"
         assert report.product_count() == 1
-        assert list(report.iter_products()) == [product]
+        product = list(report.iter_products())[0]
+        assert product.score == state.score
 
     def test_get_adviser_instance(self, predictor_mock: Predictor) -> None:
         """Test getting a resolver for adviser."""

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1522,9 +1522,9 @@ class TestResolver(AdviserTestCase):
 
         resolver._init_context()
 
-        resolver.should_receive("_do_resolve_states_raw").with_args(with_devel=True, user_stack_scoring=True,).and_yield(
-            final_state1, final_state2
-        ).once()
+        resolver.should_receive("_do_resolve_states_raw").with_args(
+            with_devel=True, user_stack_scoring=True,
+        ).and_yield(final_state1, final_state2).once()
 
         flexmock(Product)
         Product.should_receive("from_final_state").with_args(context=resolver.context, state=final_state1).and_return(

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1390,7 +1390,7 @@ class TestResolver(AdviserTestCase):
             final_state
         ).once()
 
-        states = list(resolver._do_resolve_states(with_devel=True, user_stack_scoring=True))
+        states = list(resolver._do_resolve_states_raw(with_devel=True, user_stack_scoring=True))
         assert states == [final_state]
         assert resolver.context.iteration == 2
         assert resolver.context.accepted_final_states_count == 1
@@ -1497,7 +1497,7 @@ class TestResolver(AdviserTestCase):
         state = State()
         resolver.should_receive("_prepare_initial_state").with_args(with_devel=True).and_return(state).once()
 
-        states = list(resolver._do_resolve_states(with_devel=True, user_stack_scoring=True))
+        states = list(resolver._do_resolve_states_raw(with_devel=True, user_stack_scoring=True))
         assert states == []
         assert resolver.context.iteration == 0
         assert resolver.context.accepted_final_states_count == 0
@@ -1522,7 +1522,7 @@ class TestResolver(AdviserTestCase):
 
         resolver._init_context()
 
-        resolver.should_receive("_do_resolve_states").with_args(with_devel=True, user_stack_scoring=True,).and_yield(
+        resolver.should_receive("_do_resolve_states_raw").with_args(with_devel=True, user_stack_scoring=True,).and_yield(
             final_state1, final_state2
         ).once()
 
@@ -1551,7 +1551,7 @@ class TestResolver(AdviserTestCase):
 
         resolver._init_context()
 
-        resolver.should_receive("_do_resolve_states").with_args(with_devel=True, user_stack_scoring=True).and_yield(
+        resolver.should_receive("_do_resolve_states_raw").with_args(with_devel=True, user_stack_scoring=True).and_yield(
             final_state1
         ).and_raise(EagerStopPipeline).once()
 
@@ -1577,7 +1577,7 @@ class TestResolver(AdviserTestCase):
         with pytest.raises(ValueError):
             assert resolver.context, "Context is already bound to resolver"
 
-        resolver.should_receive("_do_resolve_products").with_args(with_devel=False, user_stack_scoring=True).and_return(
+        resolver.should_receive("_do_resolve_states").with_args(with_devel=False, user_stack_scoring=True).and_return(
             []
         ).once()
 
@@ -1591,7 +1591,7 @@ class TestResolver(AdviserTestCase):
     def test_resolve(self, resolver: Resolver) -> None:
         """Test report creation during resolution."""
         product = flexmock(score=1.0)
-        resolver.should_receive("_do_resolve_products").with_args(with_devel=True, user_stack_scoring=True).and_return(
+        resolver.should_receive("_do_resolve_states").with_args(with_devel=True, user_stack_scoring=True).and_return(
             [product]
         ).once()
         resolver.pipeline.should_receive("call_post_run_report").once()

--- a/thoth/adviser/report.py
+++ b/thoth/adviser/report.py
@@ -55,15 +55,17 @@ class Report:
         """Set stack information."""
         self._stack_info = stack_info
 
-    def add_product(self, product: Product) -> None:
+    def add_product(self, product: Product) -> bool:
         """Add adviser pipeline product to report."""
         item = ((product.score, self._heapq_counter), product)
         self._heapq_counter -= 1
 
         if len(self._heapq) >= self.count:
-            heapq.heappushpop(self._heapq, item)
+            popped = heapq.heappushpop(self._heapq, item)
+            return popped is not item
         else:
             heapq.heappush(self._heapq, item)
+            return True
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert pipeline report to a dict representation."""


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #1492

## This introduces a breaking change

- [x] No
