### PR TITLE
Add justification to stack info if a package with CVE is avoided

### DIFF
--- a/tests/steps/test_cve.py
+++ b/tests/steps/test_cve.py
@@ -118,7 +118,7 @@ class TestCvePenalizationStep(AdviserUnitTestCase):
             develop=False,
         )
 
-        context = flexmock(graph=GraphDatabase(), recommendation_type=RecommendationType.SECURITY)
+        context = flexmock(graph=GraphDatabase(), recommendation_type=RecommendationType.SECURITY, stack_info=[])
         step = CvePenalizationStep()
         with CvePenalizationStep.assigned_context(context):
             assert not step._messages_logged
@@ -127,3 +127,6 @@ class TestCvePenalizationStep(AdviserUnitTestCase):
 
         assert len(step._messages_logged) == 1
         assert ("flask", "0.12.0", "https://pypi.org/simple") in step._messages_logged
+        assert len(context.stack_info) == 1
+        assert set(context.stack_info[0].keys()) == {"message", "link", "type"}
+        assert self.verify_justification_schema(context.stack_info)

--- a/thoth/adviser/steps/cve.py
+++ b/thoth/adviser/steps/cve.py
@@ -99,11 +99,18 @@ class CvePenalizationStep(Step):
                 if package_version_tuple not in self._messages_logged:
                     self._messages_logged.add(package_version_tuple)
                     for cve_record in cve_records:
+                        message = (
+                            f"Skipping including package {package_version_tuple!r} as a CVE "
+                            f"{cve_record.get('cve_name') or cve_record.get('cve_id')!r} was found"
+                        )
                         _LOGGER.warning(
-                            "Skipping including package %r as a CVE %s was found: %s",
-                            package_version_tuple,
-                            cve_record.get("cve_name") or cve_record.get("cve_id"),
+                            "%s: %s",
+                            message,
                             cve_record["advisory"],
+                        )
+
+                        self.context.stack_info.append(
+                            {"type": "WARNING", "message": message, "link": self._JUSTIFICATION_LINK}
                         )
 
                 raise NotAcceptable


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

With this change, adviser will report any packages that were removed from the resolution if they would include a security vulnerability. This message is reported only for the security recommendation type.