### PR TITLE
Implement a sieve that filters out TensorFlow==2.4.0 on non-AVX2 CPU

### DIFF
--- a/tests/sieves/tensorflow/test_tf_240_avx2.py
+++ b/tests/sieves/tensorflow/test_tf_240_avx2.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test a sieve that filters out TensorFlow==2.4.0 build as it requires AVX2 instruction set."""
+
+from typing import Optional
+
+import pytest
+
+from thoth.adviser.context import Context
+from thoth.adviser.enums import DecisionType
+from thoth.adviser.enums import RecommendationType
+from thoth.adviser.pipeline_builder import PipelineBuilderContext
+from thoth.adviser.sieves import TensorFlow240AVX2IllegalInstructionSieve
+from thoth.python import PackageVersion
+from thoth.python import Source
+
+from ...base import AdviserUnitTestCase
+
+
+class TestTensorFlowAVX2Step(AdviserUnitTestCase):
+    """Test a sieve that filters out TensorFlow==2.4.0 build as it requires AVX2 instruction set."""
+
+    UNIT_TESTED = TensorFlow240AVX2IllegalInstructionSieve
+
+    def test_verify_multiple_should_include(self, builder_context: PipelineBuilderContext) -> None:
+        """Verify multiple should_include calls do not loop endlessly."""
+        builder_context.recommendation_type = RecommendationType.STABLE
+        # Not None and not in AVX2 CPUs listing.
+        builder_context.project.runtime_environment.hardware.cpu_family = 0x0
+        builder_context.project.runtime_environment.hardware.cpu_model = 0x0
+        self.verify_multiple_should_include(builder_context)
+
+    @pytest.mark.parametrize("recommendation_type", [RecommendationType.STABLE, RecommendationType.TESTING])
+    def test_include(self, builder_context: PipelineBuilderContext, recommendation_type: RecommendationType) -> None:
+        """Test including this pipeline unit."""
+        builder_context.decision_type = None
+        builder_context.recommendation_type = recommendation_type
+        # Not None and not in AVX2 CPUs listing.
+        builder_context.project.runtime_environment.hardware.cpu_family = 0x0
+        builder_context.project.runtime_environment.hardware.cpu_model = 0x0
+        assert builder_context.is_adviser_pipeline()
+        assert self.UNIT_TESTED.should_include(builder_context) == {}
+
+    @pytest.mark.parametrize(
+        "recommendation_type,decision_type,cpu_family,cpu_model",
+        [
+            (RecommendationType.STABLE, None, None, None),  # No CPU info.
+            (RecommendationType.TESTING, None, 0x6, 0xF),  # AVX2 support in CPU.
+            (None, DecisionType.RANDOM, 0x0, 0x0),  # A Dependency Monkey run.
+        ],
+    )
+    def test_no_include(
+        self,
+        builder_context: PipelineBuilderContext,
+        recommendation_type,
+        decision_type: DecisionType,
+        cpu_family: Optional[int],
+        cpu_model: Optional[int],
+    ) -> None:
+        """Test not including this pipeline unit step."""
+        builder_context.decision_type = decision_type
+        builder_context.recommendation_type = recommendation_type
+        builder_context.project.runtime_environment.hardware.cpu_family = cpu_family
+        builder_context.project.runtime_environment.hardware.cpu_model = cpu_model
+        assert self.UNIT_TESTED.should_include(builder_context) is None
+
+    def test_tf_avx2(self, context: Context) -> None:
+        """Test recommending TensorFlow with AVX2 support."""
+        package_version = PackageVersion(
+            name="tensorflow",
+            version="==2.4.0",
+            develop=False,
+            index=Source("https://pypi.org/simple"),
+        )
+
+        assert not context.stack_info
+
+        with self.UNIT_TESTED.assigned_context(context):
+            unit = self.UNIT_TESTED()
+            result = list(unit.run((pv for pv in [package_version])))
+            assert len(result) == 0
+
+        assert len(context.stack_info) == 1
+
+        justification = context.stack_info[0]
+        assert set(justification.keys()) == {"type", "message", "link"}
+        assert justification["type"] == "WARNING"
+        assert justification["link"]
+        assert justification["message"]
+
+    def test_no_tf_avx2(self, context: Context) -> None:
+        """Test not recommending TensorFlow without AVX2 support."""
+        package_version = PackageVersion(
+            name="tensorflow",
+            version="==2.4.0",
+            develop=False,
+            index=Source("https://thoth-station.ninja/simple"),
+        )
+
+        assert not context.stack_info
+
+        with self.UNIT_TESTED.assigned_context(context):
+            unit = self.UNIT_TESTED()
+            result = list(unit.run((pv for pv in [package_version])))
+            assert len(result) == 1
+            assert result[0] is package_version
+
+        assert not context.stack_info

--- a/thoth/adviser/sieves/__init__.py
+++ b/thoth/adviser/sieves/__init__.py
@@ -30,6 +30,7 @@ from .pandas import PandasPy36Sieve
 from .prereleases import CutPreReleasesSieve
 from .setuptools import Py36SetuptoolsSieve
 from .solved import SolvedSieve
+from .tensorflow import TensorFlow240AVX2IllegalInstructionSieve
 from .tensorflow import TensorFlowAPISieve
 from .tensorflow import TensorFlowCUDASieve
 from .tensorflow import TensorFlowPython39Sieve
@@ -53,6 +54,7 @@ __all__ = [
     "ImportlibResourcesBackportSieve",
     "MockBackportSieve",
     "Py36SetuptoolsSieve",
+    "TensorFlow240AVX2IllegalInstructionSieve",
     "TensorFlowAPISieve",
     "TensorFlowCUDASieve",
     "TensorFlowPython39Sieve",

--- a/thoth/adviser/sieves/tensorflow/__init__.py
+++ b/thoth/adviser/sieves/tensorflow/__init__.py
@@ -17,12 +17,14 @@
 
 """Implementation of sieves used, specific for TensorFlow."""
 
+from .tf_240_avx2 import TensorFlow240AVX2IllegalInstructionSieve
 from .tf_api import TensorFlowAPISieve
 from .tf_cuda import TensorFlowCUDASieve
 from .tf_py39 import TensorFlowPython39Sieve
 
 
 __all__ = [
+    "TensorFlow240AVX2IllegalInstructionSieve",
     "TensorFlowAPISieve",
     "TensorFlowCUDASieve",
     "TensorFlowPython39Sieve",

--- a/thoth/adviser/sieves/tensorflow/tf_240_avx2.py
+++ b/thoth/adviser/sieves/tensorflow/tf_240_avx2.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""A sieve that filters out TensorFlow==2.4.0 build as it requires AVX2 instruction set."""
+
+from typing import Any
+from typing import Dict
+from typing import Generator
+from typing import Optional
+from typing import TYPE_CHECKING
+import logging
+
+from thoth.common import get_justification_link as jl
+from thoth.python import PackageVersion
+
+from ...enums import RecommendationType
+from ...sieve import Sieve
+from ...steps.tensorflow.tf_avx2 import TensorFlowAVX2Step
+
+
+if TYPE_CHECKING:
+    from ..pipeline_builder import PipelineBuilderContext
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TensorFlow240AVX2IllegalInstructionSieve(Sieve):
+    """A sieve that filters out TensorFlow==2.4.0 build as it requires AVX2 instruction set.
+
+    See:
+     * https://github.com/tensorflow/tensorflow/issues/45866
+     * https://github.com/tensorflow/tensorflow/issues/45744
+    """
+
+    CONFIGURATION_DEFAULT = {"package_name": "tensorflow"}
+
+    _JUSTIFICATION_ADDITION = {
+        "type": "WARNING",
+        "message": "Upstream TensorFlow=2.4.0 build filtered out as it requires AVX2 instruction "
+        "set support which is not available.",
+        "link": jl("tf_240_avx2"),
+    }
+
+    @classmethod
+    def should_include(cls, builder_context: "PipelineBuilderContext") -> Optional[Dict[str, Any]]:
+        """Register this pipeline unit for adviser and stable/testing recommendation types."""
+        if not builder_context.is_adviser_pipeline():
+            return None
+
+        if builder_context.recommendation_type == RecommendationType.LATEST:
+            return None
+
+        cpu_tuple = (
+            builder_context.project.runtime_environment.hardware.cpu_family,
+            builder_context.project.runtime_environment.hardware.cpu_model,
+        )
+
+        if any(i is None for i in cpu_tuple):
+            return None
+
+        if cpu_tuple in TensorFlowAVX2Step.AVX2_CPUS:
+            # AVX2 supported, TensorFlow will work.
+            return None
+
+        if not builder_context.is_included(cls):
+            return {}
+
+        return None
+
+    def run(self, package_versions: Generator[PackageVersion, None, None]) -> Generator[PackageVersion, None, None]:
+        """Recommend not to use TensorFlow==2.4.0 on non-AVX2 enabled CPU processors."""
+        for package_version in package_versions:
+            if (
+                package_version.name == "tensorflow"
+                and package_version.locked_version == "2.4.0"
+                and package_version.index.url == "https://pypi.org/simple"
+            ):
+                self.context.stack_info.append(self._JUSTIFICATION_ADDITION)
+                continue
+
+            yield package_version

--- a/thoth/adviser/steps/tensorflow/tf_avx2.py
+++ b/thoth/adviser/steps/tensorflow/tf_avx2.py
@@ -59,7 +59,7 @@ class TensorFlowAVX2Step(Step):
     # A tuple (CPU_FAMILY, CPU_MODEL) of Intel processors supporting AVX2:
     #   https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#CPUs_with_AVX2
     #   https://en.wikichip.org/wiki/intel/cpuid
-    _AVX2_CPUS = frozenset(
+    AVX2_CPUS = frozenset(
         {
             (0x6, 0x5),  # Cascade Lake
             (0x6, 0x6),  # Broadwell, Cannon Lake
@@ -84,7 +84,7 @@ class TensorFlowAVX2Step(Step):
             builder_context.project.runtime_environment.hardware.cpu_family,
             builder_context.project.runtime_environment.hardware.cpu_model,
         )
-        if cpu_tuple not in cls._AVX2_CPUS:
+        if cpu_tuple not in cls.AVX2_CPUS:
             # No AVX2 support for the given CPU or no CPU info.
             return None
 


### PR DESCRIPTION
## Related Issues and Dependencies

Related: #1616
Related: https://github.com/tensorflow/tensorflow/issues/45866 
Related: https://github.com/tensorflow/tensorflow/issues/45744

## This introduces a breaking change

- [x] No
