### PR TITLE
Add Thoth's landing page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,11 +3,9 @@ Welcome to Thoth's adviser documentation
 
 Thoth's adviser is a recommendation engine for Python applications.
 
-This documentation corresponds to a component called "adviser". Sources can be
-found on `GitHub <https://github.com/thoth-station/adviser>`_.
+.. note::
 
-See `thoth-station <https://thoth-station.ninja>`_ website and `Thoth-Station
-organization on GitHub <https://github.com/thoth-station>`_.
+  See ":ref:`Thoth's landing page <landing_page>`" to see generic info if you are new to Thoth.
 
 Introductory sections
 =====================

--- a/docs/source/landing_page.rst
+++ b/docs/source/landing_page.rst
@@ -1,0 +1,74 @@
+.. _landing_page:
+
+Thoth's landing page
+--------------------
+
+Here you can find all the relevant information if you want to get in touch with
+us or get involved.
+
+.. note::
+
+  If you do not find required information, feel free to contact us in
+  `Google Chat room <https://chat.google.com/room/AAAAVjnVXFk>`__.
+
+Generic Information
+===================
+
+* `YouTube channel <https://www.youtube.com/channel/UClUIDuq_hQ6vlzmqM59B2Lw>`__
+* `Twitter <https://twitter.com/ThothStation>`__
+* `Conference talks and articles published <https://github.com/thoth-station/talks>`__
+
+
+Contact information
+===================
+
+You can be added to our Google Chat room where we can interact instantly. To do
+so, follow instructions in the `thoth-station/core repository
+<https://github.com/thoth-station/core/blob/master/README.rst>`__.
+
+Event Calendar
+==============
+
+Follow instructions in the `thoth-station/core repository
+<https://github.com/thoth-station/core/blob/master/README.rst>`__ to find
+interesting sessions we do.
+
+SIG
+===
+
+The whole team is formed into "Special Interest Groups" (SIG). More info can be
+found in the `thoth-station/core repository
+<https://github.com/thoth-station/core/blob/master/README.rst>`__.
+
+Cooperation with Thoth
+======================
+
+Internship
+##########
+
+Each year we work with university students which are involved in the project
+and can gain valuable technical experience with cutting edge technologies.
+Besides technical knowledge and experience, this cooperation also brings the
+feel of `open source culture we support
+<https://www.redhat.com/en/about/our-culture>`__. If you want to get in, do not
+hesitate to contact us. Some of our colleages participated in this process and
+are very valuable engineers in our team. We work with Boston University, Brno
+University of Technology and Masaryk University but we are open to work with
+other universities as well.
+
+Bachelor and Diploma Theses
+###########################
+
+If you are a university student seeking for a bachelor or diploma thesis, we
+can offer a cooperation. An example of bachelor and diploma thesis we did with
+a coop with Brno University of Technology and Brno Masaryk University:
+
+* `Checking performance characteristics of AI/ML libraries <https://research.redhat.com/blog/engineering_project/checking-performance-characteristics-of-ai-ml-libraries/>`__
+* `Distributed machine learning training on OpenShift <https://research.redhat.com/blog/engineering_project/distributed-machine-learning-training-on-openshift/>`__
+* `Predicting software stack issues in popular AI/ML libraries <https://research.redhat.com/blog/engineering_project/predicting-software-stack-issues-in-popular-ai-ml-libraries/>`__
+
+We are not limited to the university listing stated. Also, we are not limited
+to the listing of available projects on `Red Hat research site
+<https://research.redhat.com/>`__. If you want to sign up for a thesis with us,
+do not hesitate to contact us. We can discuss your ideas or create a thesis
+suitable for you.


### PR DESCRIPTION
The purpose of this page is to create a crossroad for people who want to get involved in Thoth or are seeking information so we can provide a simple link to them. As of now, this summary is more university/internship oriented, but we can extend it as desired.

## This introduces a breaking change

- [x] No
