### PR TITLE
Invert inclusion logic, include if Thoth s2i is not used

### DIFF
--- a/tests/wraps/test_thoth_s2i.py
+++ b/tests/wraps/test_thoth_s2i.py
@@ -35,14 +35,14 @@ class TestThothS2IWrap(AdviserUnitTestCase):
 
     def test_verify_multiple_should_include(self, builder_context: PipelineBuilderContext) -> None:
         """Verify multiple should_include calls do not loop endlessly."""
-        builder_context.project.runtime_environment.base_image = "quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.23.0"
+        builder_context.project.runtime_environment.base_image = "rhel:8"
         self.verify_multiple_should_include(builder_context)
 
     @pytest.mark.parametrize("base_image", [None, "fedora:33", "quay.io/thoth-station/solver-ubi8-py38:v0.23.0"])
-    def test_no_include(self, base_image: Optional[str], builder_context: PipelineBuilderContext) -> None:
+    def test_include(self, base_image: Optional[str], builder_context: PipelineBuilderContext) -> None:
         """Test not including the pipeline unit."""
         builder_context.project.runtime_environment.base_image = base_image
-        assert self.UNIT_TESTED.should_include(builder_context) is None
+        assert self.UNIT_TESTED.should_include(builder_context) is not None
 
     def test_run(self, context: Context) -> None:
         """Test running and recommending to use Thoth's s2i base image."""

--- a/thoth/adviser/wraps/thoth_s2i.py
+++ b/thoth/adviser/wraps/thoth_s2i.py
@@ -49,7 +49,7 @@ class ThothS2IWrap(Wrap):
 
         base_image = builder_context.project.runtime_environment.base_image
 
-        if base_image and not base_image.startswith(cls._THOTH_S2I_PREFIX):
+        if base_image is None or (base_image and not base_image.startswith(cls._THOTH_S2I_PREFIX)):
             return {}
 
         return None


### PR DESCRIPTION
Fix a bug related to wrong logic of inclusion this pipeline unit - we want to include the unit if Thoth s2i is **not** used.