### PR TITLE
Do not enable cut pre-releases step if selective pre-releases are allowed

### DIFF
--- a/tests/sieves/test_prereleases.py
+++ b/tests/sieves/test_prereleases.py
@@ -71,6 +71,22 @@ tensorflow = "*"
 allow_prereleases = true
 """
 
+    _CASE_SELECTIVE_PRERELEASES_ALLOWED_PIPFILE = """
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+tensorflow = "*"
+
+[pipenv]
+allow_prereleases = true
+
+[thoth.allow_prereleases]
+tensorflow = true
+"""
+
     @pytest.mark.parametrize(
         "recommendation_type",
         [
@@ -111,6 +127,14 @@ allow_prereleases = true
         """Test not including this pipeline unit."""
         builder_context.recommendation_type = recommendation_type
         builder_context.project = Project.from_strings(self._CASE_ALLOWED_PIPFILE)
+
+        assert builder_context.is_adviser_pipeline()
+        assert CutPreReleasesSieve.should_include(builder_context) is None
+
+    def test_not_include_thoth_prereleases_allowed(self, builder_context: PipelineBuilderContext) -> None:
+        """Test not including this pipeline unit."""
+        builder_context.recommendation_type = RecommendationType.LATEST
+        builder_context.project = Project.from_strings(self._CASE_SELECTIVE_PRERELEASES_ALLOWED_PIPFILE)
 
         assert builder_context.is_adviser_pipeline()
         assert CutPreReleasesSieve.should_include(builder_context) is None

--- a/thoth/adviser/sieves/prereleases.py
+++ b/thoth/adviser/sieves/prereleases.py
@@ -44,7 +44,9 @@ class CutPreReleasesSieve(Sieve):
     @classmethod
     def should_include(cls, builder_context: "PipelineBuilderContext") -> Optional[Dict[str, Any]]:
         """Include cut-prereleases pipeline sieve for adviser or Dependency Monkey if pre-releases are not allowed."""
-        if builder_context.project.prereleases_allowed:
+        if builder_context.project.prereleases_allowed or (
+            builder_context.project.pipfile.thoth and builder_context.project.pipfile.thoth.allow_prereleases
+        ):
             _LOGGER.info("Project accepts pre-releases, skipping cutting pre-releases step")
             return None
 


### PR DESCRIPTION
## Related Issues and Dependencies

Otherwise the functionality clashes and produces undesired results (no selective pre-releases are done).

## This introduces a breaking change

- [x] No
