### PR TITLE
Thoth's additional features can be None

### DIFF
--- a/thoth/adviser/sieves/experimental_prereleases.py
+++ b/thoth/adviser/sieves/experimental_prereleases.py
@@ -56,7 +56,11 @@ class SelectiveCutPreReleasesSieve(Sieve):
 
             return None
 
-        if builder_context.is_included(cls) or not builder_context.project.pipfile.thoth.allow_prereleases:
+        if (
+            builder_context.is_included(cls)
+            or not builder_context.project.pipfile.thoth
+            or not builder_context.project.pipfile.thoth.allow_prereleases
+        ):
             return None
 
         return {


### PR DESCRIPTION
## Related Issues and Dependencies

```
  File "/opt/app-root/lib64/python3.8/site-packages/click/decorators.py", line 21, in new_
func
    return callback(*args, **kwargs)
  File "thoth-adviser", line 494, in advise
    return f(get_current_context(), *args, **kwargs)
    resolver = Resolver.get_adviser_instance(
  File "/opt/app-root/src/thoth/adviser/resolver.py", line 1394, in get_adviser_instance
    pipeline = PipelineBuilder.get_adviser_pipeline_config(
  File "/opt/app-root/src/thoth/adviser/pipeline_builder.py", line 457, in get_adviser_pip
eline_config
  File "/opt/app-root/src/thoth/adviser/pipeline_builder.py", line 297, in _build_configur
ation
    return cls._build_configuration(
    unit_configuration = unit_class.should_include(ctx)  # type: ignore
  File "/opt/app-root/src/thoth/adviser/sieves/experimental_prereleases.py", line 59, in s
hould_include
    if builder_context.is_included(cls) or not builder_context.project.pipfile.thoth.allow
_prereleases:
AttributeError2021-02-09T09:56:16.282958049Z : 'NoneType' object has no attribute 'allow_p
rereleases'
```

## This introduces a breaking change

- [x] No
