### PR TITLE
Introduce a sieve to filter out legacy versions from the resolution

### DIFF
--- a/tests/sieves/test_legacy_version.py
+++ b/tests/sieves/test_legacy_version.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test removing legacy versions from the resolution process."""
+
+from thoth.adviser.context import Context
+from thoth.adviser.sieves import LegacyVersionSieve
+from thoth.adviser.enums import RecommendationType
+from thoth.adviser.pipeline_builder import PipelineBuilderContext
+from thoth.python import Source
+from thoth.python import PackageVersion
+
+from ..base import AdviserUnitTestCase
+
+
+class TestLegacyVersionSieve(AdviserUnitTestCase):
+    """Test removing legacy versions from the resolution process."""
+
+    UNIT_TESTED = LegacyVersionSieve
+
+    def test_verify_multiple_should_include(self) -> None:
+        """Verify multiple should_include calls do not loop endlessly."""
+        builder_context = PipelineBuilderContext(recommendation_type=RecommendationType.LATEST)
+        self.verify_multiple_should_include(builder_context)
+
+    def test_include(
+        self,
+        builder_context: PipelineBuilderContext,
+    ) -> None:
+        """Test including this pipeline unit."""
+        builder_context.recommendation_type = RecommendationType.LATEST
+        assert builder_context.is_adviser_pipeline()
+        assert self.UNIT_TESTED.should_include(builder_context) == {}
+
+    def test_remove_legacy_version_noop(self, context: Context) -> None:
+        """Test not removing not legacy versions."""
+        pv1 = PackageVersion(
+            name="flask",
+            version="==0.0dev0",
+            index=Source("https://pypi.org/simple"),
+            develop=False,
+        )
+
+        pv2 = PackageVersion(
+            name="tensorflow",
+            version="==2.0.0rc0",
+            index=pv1.index,
+            develop=False,
+        )
+
+        with self.UNIT_TESTED.assigned_context(context):
+            sieve = self.UNIT_TESTED()
+            assert list(sieve.run(p for p in [pv1, pv2])) == [pv1, pv2]
+
+    def test_remove_legacy_version(self, context: Context) -> None:
+        """Test removing legacy versions."""
+        pv1 = PackageVersion(
+            name="flask",
+            version="==foo",
+            index=Source("https://pypi.org/simple"),
+            develop=False,
+        )
+
+        with self.UNIT_TESTED.assigned_context(context):
+            sieve = self.UNIT_TESTED()
+            assert list(sieve.run(p for p in [pv1])) == []

--- a/thoth/adviser/sieves/__init__.py
+++ b/thoth/adviser/sieves/__init__.py
@@ -24,6 +24,7 @@ from .backports import ImportlibResourcesBackportSieve
 from .backports import MockBackportSieve
 from .filter_index import FilterIndexSieve
 from .index_enabled import PackageIndexSieve
+from .legacy_version import LegacyVersionSieve
 from .locked import CutLockedSieve
 from .pandas import PandasPy36Sieve
 from .prereleases import CutPreReleasesSieve
@@ -37,11 +38,11 @@ from .tensorflow import TensorFlowPython39Sieve
 from .thoth_s2i_abi_compat import ThothS2IAbiCompatibilitySieve
 from .version_constraint import VersionConstraintSieve
 
-
 # Relative ordering of units is relevant, as the order specifies order
 # in which the asked to be registered - any dependencies between them
 # can be mentioned here.
 __all__ = [
+    "LegacyVersionSieve",
     "CutPreReleasesSieve",
     "SelectiveCutPreReleasesSieve",
     "CutLockedSieve",

--- a/thoth/adviser/sieves/legacy_version.py
+++ b/thoth/adviser/sieves/legacy_version.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""A sieve to filter out legacy versions."""
+
+import logging
+from typing import Optional
+from typing import Dict
+from typing import Any
+from typing import Generator
+from typing import TYPE_CHECKING
+
+import attr
+from thoth.python import PackageVersion
+
+from ..sieve import Sieve
+
+if TYPE_CHECKING:
+    from ..pipeline_builder import PipelineBuilderContext
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@attr.s(slots=True)
+class LegacyVersionSieve(Sieve):
+    """A sieve to filter out legacy versions.
+
+    This sieve assumes no recent projects use legacy versions hence we can
+    simply skip them in the resolution process.
+    """
+
+    CONFIGURATION_DEFAULT = {"package_name": None}
+
+    @classmethod
+    def should_include(cls, builder_context: "PipelineBuilderContext") -> Optional[Dict[str, Any]]:
+        """Include this sieve once, always."""
+        if not builder_context.is_included(cls):
+            return {}
+
+        return None
+
+    def run(self, package_versions: Generator[PackageVersion, None, None]) -> Generator[PackageVersion, None, None]:
+        """Cut-off legacy versions from the resolution process."""
+        for package_version in package_versions:
+            if package_version.semantic_version.is_legacy_version:
+                _LOGGER.warning(
+                    "Removing package %s as the version identifier is a legacy version string",
+                    package_version.to_tuple(),
+                )
+                continue
+
+            yield package_version


### PR DESCRIPTION
## Related Issues and Dependencies

Depends-On: https://github.com/thoth-station/python/pull/343/files

## This introduces a breaking change

- [x] No

## This Pull Request implements

With this pipeline unit, we will filter out legacy versions from the resolution process. The assumption is that these version identifiers are not used for quite some time.