### PR TITLE
Remove invalid entry from sieves

### DIFF
--- a/thoth/adviser/sieves/__init__.py
+++ b/thoth/adviser/sieves/__init__.py
@@ -47,7 +47,6 @@ __all__ = [
     "LegacyVersionSieve",
     "CutPreReleasesSieve",
     "SelectiveCutPreReleasesSieve",
-    "FilterAssignedIndexSieve",
     "FilterConfiguredIndexSieve",
     "PackageIndexConfigurationSieve",
     "CutLockedSieve",


### PR DESCRIPTION
## Related Issues and Dependencies

```
  File "./thoth-adviser", line 790, in <module>
    __name__ == "__main__" and cli()
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "./thoth-adviser", line 498, in advise
    resolver = Resolver.get_adviser_instance(
  File "/home/fpokorny/git/thoth-station/adviser/thoth/adviser/resolver.py", line 1394, in get_adviser_instance
    pipeline = PipelineBuilder.get_adviser_pipeline_config(
  File "/home/fpokorny/git/thoth-station/adviser/thoth/adviser/pipeline_builder.py", line 457, in get_adviser_pipeline_config
    return cls._build_configuration(
  File "/home/fpokorny/git/thoth-station/adviser/thoth/adviser/pipeline_builder.py", line 289, in _build_configuration
    for unit_class in cls._iter_units():
  File "/home/fpokorny/git/thoth-station/adviser/thoth/adviser/pipeline_builder.py", line 262, in _iter_units
    yield getattr(thoth.adviser.sieves, sieve_name)
AttributeError: module 'thoth.adviser.sieves' has no attribute 'FilterAssignedIndexSieve'
```

## This introduces a breaking change

- [x] No
