### PR TITLE
Normalize score returned from CVE step score

### DIFF
--- a/thoth/adviser/steps/cve.py
+++ b/thoth/adviser/steps/cve.py
@@ -123,6 +123,6 @@ class CvePenalizationStep(Step):
                 record["package_name"] = package_version.name
                 record["link"] = self._JUSTIFICATION_LINK
 
-            return penalization, cve_records
+            return max(penalization, -1.0), cve_records
 
         return None


### PR DESCRIPTION
## Related Issues and Dependencies

```
2021-03-08 12:35:12,180 thoth.adviser.resolver      WARNING: Step 'CvePenalizationStep' returned score lower than allowed (-1.6), normalizing to -1
```

## This introduces a breaking change

- [x] No
