### PR TITLE
Relax strict match for prescription wrap pipeline units

### DIFF
--- a/thoth/adviser/prescription/v1/schema.py
+++ b/thoth/adviser/prescription/v1/schema.py
@@ -307,7 +307,7 @@ PRESCRIPTION_WRAP_RUN_SCHEMA = Schema(
         Optional("not_acceptable"): _NONEMPTY_STRING,
         Optional("eager_stop_pipeline"): _NONEMPTY_STRING,
         Optional("justification"): [JUSTIFICATION_SCHEMA],
-        Required("match"): Schema(
+        Optional("match"): Schema(
             {Required("state"): Schema({Required("resolved_dependencies"): [PACKAGE_VERSION_SCHEMA]})}
         ),
         **_UNIT_RUN_SCHEMA_BASE_DICT,

--- a/thoth/adviser/prescription/v1/unit.py
+++ b/thoth/adviser/prescription/v1/unit.py
@@ -290,7 +290,7 @@ class UnitPrescription(Unit, metaclass=abc.ABCMeta):
 
     def _run_state(self, state: State) -> bool:
         """Check state match."""
-        state_prescription = self.run_prescription["match"].get("state")
+        state_prescription = self.run_prescription.get("match", {}).get("state")
         if state_prescription:
             for resolved_dependency in state_prescription.get("resolved_dependencies", []):
                 resolved = state.resolved_dependencies.get(resolved_dependency["name"])


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
