### PR TITLE
Keep optimization for prescription wraps with resolved dependencies

### DIFF
--- a/tests/prescription/v1/test_wrap.py
+++ b/tests/prescription/v1/test_wrap.py
@@ -246,6 +246,28 @@ run:
         WrapPrescription.set_prescription(prescription)
 
         builder_context = flexmock()
+        assert list(WrapPrescription.should_include(builder_context)) == [{"package_name": "flask"}]
+
+    def test_should_include_no_package_name(self) -> None:
+        """Test including this pipeline unit without any specific resolved package."""
+        prescription_str = """
+name: WrapUnit
+type: wrap
+should_include:
+  times: 1
+  adviser_pipeline: true
+run:
+  justification:
+    - type: ERROR
+      message: This message will not be shown
+      link: https://pypi.org/project/connexion
+"""
+        flexmock(WrapPrescription).should_receive("_should_include_base").replace_with(lambda _: True).once()
+        prescription = yaml.safe_load(prescription_str)
+        PRESCRIPTION_WRAP_SCHEMA(prescription)
+        WrapPrescription.set_prescription(prescription)
+
+        builder_context = flexmock()
         assert list(WrapPrescription.should_include(builder_context)) == [{}]
 
     def test_no_should_include(self) -> None:

--- a/thoth/adviser/prescription/v1/wrap.py
+++ b/thoth/adviser/prescription/v1/wrap.py
@@ -44,7 +44,15 @@ class WrapPrescription(UnitPrescription):
     def should_include(cls, builder_context: "PipelineBuilderContext") -> Generator[Dict[str, Any], None, None]:
         """Check if the given pipeline unit should be included in the given pipeline configuration."""
         if cls._should_include_base(builder_context):
-            yield {}
+            match_resolved = (
+                cls._PRESCRIPTION["run"].get("match", {}).get("state", {}).get("resolved_dependencies")  # type: ignore
+            )
+            if match_resolved:
+                # Return the first package name that should be matched to keep optimization for wrap calls.
+                yield {"package_name": match_resolved[0].get("name")}
+            else:
+                yield {}
+
             return None
 
         yield from ()


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
