### PR TITLE
Add update sieve responsible for package updates

### DIFF
--- a/tests/sieves/test_update.py
+++ b/tests/sieves/test_update.py
@@ -42,7 +42,7 @@ class TestPackageUpdateSieve(AdviserUnitTestCase):
     }
 
     @pytest.mark.skip(
-        reason="Skip default configuration as default is not considered valid and needs futher adjustments"
+        reason="Skip default configuration as default is not considered valid and needs further adjustments"
     )
     def test_default_configuration(self) -> None:
         """Skip testing default configuration."""

--- a/tests/sieves/test_update.py
+++ b/tests/sieves/test_update.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests related to filtering out Python packages that are not part of a new release."""
+
+import json
+
+import pytest
+from thoth.adviser.enums import RecommendationType
+from thoth.adviser.pipeline_builder import PipelineBuilderContext
+from thoth.adviser.sieves import PackageUpdateSieve
+from thoth.adviser.context import Context
+from thoth.common import get_justification_link as jl
+from thoth.python import Source
+from thoth.python import PackageVersion
+
+from ..base import AdviserUnitTestCase
+
+
+class TestPackageUpdateSieve(AdviserUnitTestCase):
+    """Tests related to filtering out Python packages that are not part of a new release."""
+
+    UNIT_TESTED = PackageUpdateSieve
+    _PACKAGE_UPDATE_DICT = {
+        "package_name": "tensorflow",
+        "package_version": "2.5.0",
+        "index_url": "https://pypi.org/simple",
+    }
+
+    @pytest.mark.skip(
+        reason="Skip default configuration as default is not considered valid and needs futher adjustments"
+    )
+    def test_default_configuration(self) -> None:
+        """Skip testing default configuration."""
+
+    def test_verify_multiple_should_include(self) -> None:
+        """Verify multiple should_include calls do not loop endlessly."""
+        self.UNIT_TESTED._PACKAGE_UPDATE = json.dumps(self._PACKAGE_UPDATE_DICT)
+
+        try:
+            builder_context = PipelineBuilderContext(recommendation_type=RecommendationType.LATEST)
+            self.verify_multiple_should_include(builder_context)
+        finally:
+            self.UNIT_TESTED._PACKAGE_UPDATE = None
+
+    def test_should_include(self, builder_context: PipelineBuilderContext) -> None:
+        """Test including this pipeline unit based on supplied package."""
+        self.UNIT_TESTED._PACKAGE_UPDATE = json.dumps(self._PACKAGE_UPDATE_DICT)
+
+        try:
+            assert list(self.UNIT_TESTED.should_include(builder_context)) == [self._PACKAGE_UPDATE_DICT]
+        finally:
+            self.UNIT_TESTED._PACKAGE_UPDATE = None
+
+    def test_should_include_no_include(self, builder_context: PipelineBuilderContext) -> None:
+        """Test NOT including this pipeline unit when no package is supplied."""
+        assert self.UNIT_TESTED._PACKAGE_UPDATE is None
+
+        try:
+            assert list(self.UNIT_TESTED.should_include(builder_context)) == []
+        finally:
+            self.UNIT_TESTED._PACKAGE_UPDATE = None
+
+    def test_sieve(self, context: Context) -> None:
+        """Test removing packages that are not part of an update."""
+        pypi = Source("https://pypi.org/simple")
+        pv0 = PackageVersion(name="tensorflow", version="==2.5.0", index=pypi, develop=False)
+        pv1 = PackageVersion(name="tensorflow", version="==2.4.0", index=pypi, develop=False)
+        pv2 = PackageVersion(name="tensorflow", version="==2.3.0", index=pypi, develop=False)
+
+        assert not context.stack_info
+
+        self.UNIT_TESTED._PACKAGE_UPDATE = json.dumps(self._PACKAGE_UPDATE_DICT)
+        try:
+            unit = self.UNIT_TESTED()
+            unit.update_configuration(self._PACKAGE_UPDATE_DICT)
+
+            unit.pre_run()
+            with self.UNIT_TESTED.assigned_context(context):
+                assert list(unit.run(pv for pv in (pv0, pv1, pv2))) == [pv0]
+        finally:
+            self.UNIT_TESTED._PACKAGE_UPDATE = None
+
+        assert context.stack_info == [
+            {
+                "link": jl("update"),
+                "message": "Removing package ('tensorflow', '2.4.0', "
+                "'https://pypi.org/simple') as advising on a new release",
+                "package_name": "tensorflow",
+                "type": "WARNING",
+            },
+            {
+                "link": jl("update"),
+                "message": "Removing package ('tensorflow', '2.3.0', "
+                "'https://pypi.org/simple') as advising on a new release",
+                "package_name": "tensorflow",
+                "type": "WARNING",
+            },
+        ]

--- a/thoth/adviser/sieves/__init__.py
+++ b/thoth/adviser/sieves/__init__.py
@@ -17,27 +17,29 @@
 
 """Implementation of sieves used in adviser pipeline."""
 
-from .filter_index import FilterIndexSieve
 from .constraints import ConstraintsSieve
+from .experimental_filter_conf_index import FilterConfiguredIndexSieve
+from .experimental_package_index import PackageIndexConfigurationSieve
+from .experimental_prereleases import SelectiveCutPreReleasesSieve
+from .filter_index import FilterIndexSieve
 from .index_enabled import PackageIndexSieve
 from .legacy_version import LegacyVersionSieve
 from .locked import CutLockedSieve
 from .prereleases import CutPreReleasesSieve
-from .experimental_filter_conf_index import FilterConfiguredIndexSieve
-from .experimental_package_index import PackageIndexConfigurationSieve
-from .experimental_prereleases import SelectiveCutPreReleasesSieve
-from .solved import SolvedSieve
 from .rules import SolverRulesSieve
+from .solved import SolvedSieve
 from .tensorflow import TensorFlow240AVX2IllegalInstructionSieve
 from .tensorflow import TensorFlowAPISieve
 from .tensorflow import TensorFlowCUDASieve
 from .thoth_s2i_abi_compat import ThothS2IAbiCompatibilitySieve
+from .update import PackageUpdateSieve
 from .version_constraint import VersionConstraintSieve
 
 # Relative ordering of units is relevant, as the order specifies order
 # in which the asked to be registered - any dependencies between them
 # can be mentioned here.
 __all__ = [
+    "PackageUpdateSieve",
     "LegacyVersionSieve",
     "CutPreReleasesSieve",
     "ConstraintsSieve",

--- a/thoth/adviser/sieves/update.py
+++ b/thoth/adviser/sieves/update.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""A sieve for filtering out Python packages that are not part of a new release.
+
+This pipeline unit is registered only if adviser was requested to run to check a new
+package release. The pipeline unit filters out all the packages except for the one that
+should be included in the stack (the newly released) to check whether there is a stack
+with the released package that is better than the one used with an older release.
+"""
+
+import os
+import logging
+from typing import Any
+from typing import Dict
+from typing import Generator
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import TYPE_CHECKING
+
+import attr
+import json
+from thoth.common import get_justification_link as jl
+from thoth.adviser.enums import RecommendationType
+from thoth.python import PackageVersion
+from voluptuous import Required
+from voluptuous import Schema
+
+from ..sieve import Sieve
+
+if TYPE_CHECKING:
+    from ..pipeline_builder import PipelineBuilderContext
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@attr.s(slots=True)
+class PackageUpdateSieve(Sieve):
+    """A sieve for filtering out Python packages that are not part of a new release."""
+
+    CONFIGURATION_DEFAULT = {"package_name": None, "package_version": None, "index_url": None}
+    CONFIGURATION_SCHEMA: Schema = Schema(
+        {Required("package_name"): str, Required("package_version"): str, Required("index_url"): str}
+    )
+    _JUSTIFICATION_LINK = jl("update")
+    _PACKAGE_UPDATE = os.getenv("THOTH_ADVISER_DEPLOYMENT_PACKAGE_UPDATE")
+
+    _messages_logged = attr.ib(type=Set[Tuple[str, str, str]], factory=set, init=False)
+    _package_update = attr.ib(type=Optional[Tuple[str, str, str]], init=False, default=None)
+
+    @classmethod
+    def should_include(cls, builder_context: "PipelineBuilderContext") -> Generator[Dict[str, Any], None, None]:
+        """Include pipeline sieve."""
+        if cls._PACKAGE_UPDATE and not builder_context.is_included(cls):
+            package_update_dict = json.loads(cls._PACKAGE_UPDATE)
+
+            if builder_context.recommendation_type != RecommendationType.LATEST:
+                _LOGGER.warning(
+                    "Registering %s sieve pipeline unit when not recommending latest, this error is not critical ...",
+                    cls.__name__,
+                )
+
+            yield package_update_dict
+            return None
+
+        yield from ()
+        return None
+
+    def pre_run(self) -> None:
+        """Initialize this pipeline unit before each run."""
+        self._messages_logged.clear()
+        self._package_update = (
+            self.configuration["package_name"],
+            self.configuration["package_version"],
+            self.configuration["index_url"],
+        )
+        super().pre_run()
+
+    def run(self, package_versions: Generator[PackageVersion, None, None]) -> Generator[PackageVersion, None, None]:
+        """Filter out packages that are old releases."""
+        for package_version in package_versions:
+            package_tuple = package_version.to_tuple()
+
+            if package_tuple != self._package_update:
+                if package_tuple not in self._messages_logged:
+                    self._messages_logged.add(package_tuple)
+                    message = f"Removing package {package_tuple} as advising on a new release"
+                    _LOGGER.warning("%s - see %s", message, self._JUSTIFICATION_LINK)
+                    self.context.stack_info.append(
+                        {
+                            "type": "WARNING",
+                            "message": message,
+                            "link": self._JUSTIFICATION_LINK,
+                            "package_name": package_version.name,
+                        }
+                    )
+
+                continue
+
+            yield package_version


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/adviser/issues/1886

## This introduces a breaking change

- [x] No

## Description

With this pipeline unit, we will be able to perform updates of application stacks as triggered by the internal trigger.
