### PR TITLE
Fix wrong CVE key obtained

### DIFF
--- a/tests/steps/test_cve.py
+++ b/tests/steps/test_cve.py
@@ -43,7 +43,7 @@ class TestCvePenalizationStep(AdviserUnitTestCase):
     ]
 
     _FLASK_CVE = {
-        "description": "flask version Before 0.12.3 contains a CWE-20: Improper Input Validation "
+        "details": "flask version Before 0.12.3 contains a CWE-20: Improper Input Validation "
         "vulnerability in flask that can result in Large amount of memory usage "
         "possibly leading to denial of service.",
         "cve_id": "CVE-ID",

--- a/thoth/adviser/steps/cve.py
+++ b/thoth/adviser/steps/cve.py
@@ -107,7 +107,7 @@ class CvePenalizationStep(Step):
                         _LOGGER.warning(
                             "%s: %s",
                             message,
-                            cve_record["description"],
+                            cve_record["details"],
                         )
 
                         self.context.stack_info.append(
@@ -125,7 +125,7 @@ class CvePenalizationStep(Step):
                     {
                         "package_name": package_version.name,
                         "link": self._JUSTIFICATION_LINK,
-                        "advisory": cve_record["description"],
+                        "advisory": cve_record["details"],
                         "message": message,
                         "type": "WARNING",
                     }


### PR DESCRIPTION
## Related Issues and Dependencies

```
2021-06-11 06:36:53,993 thoth.adviser.run           ERROR: The resolution failed as an error was encountered: Failed to run step 'CvePenalizationStep' for Python package ('tensorflow', '1.5.1', 'https://pypi.org/simple'): 'description'
Traceback (most recent call last):
  File "/opt/app-root/src/thoth/adviser/resolver.py", line 354, in _run_steps
    step_result = step.run(state, package_version)
  File "/opt/app-root/src/thoth/adviser/steps/cve.py", line 110, in run
    cve_record["description"],
KeyError: 'description'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/app-root/src/thoth/adviser/run.py", line 75, in subprocess_run
    report: Union[DependencyMonkeyReport, Report] = resolver.resolve(
  File "/opt/app-root/src/thoth/adviser/resolver.py", line 1308, in resolve
    for state in self._do_resolve_states(with_devel=with_devel, user_stack_scoring=user_stack_scoring):
  File "/opt/app-root/src/thoth/adviser/resolver.py", line 1238, in _do_resolve_states
    for final_state in self._do_resolve_states_raw(
  File "/opt/app-root/src/thoth/adviser/resolver.py", line 1182, in _do_resolve_states_raw
    state_returned = self._expand_state(state, unresolved_package_tuple)
  File "/opt/app-root/src/thoth/adviser/resolver.py", line 878, in _expand_state
    return self._expand_state_add_dependencies(
  File "/opt/app-root/src/thoth/adviser/resolver.py", line 1110, in _expand_state_add_dependencies
    return self._run_steps(state, package_version, all_dependencies, newly_added)
  File "/opt/app-root/src/thoth/adviser/resolver.py", line 387, in _run_steps
    raise StepError(
thoth.adviser.exceptions.StepError: Failed to run step 'CvePenalizationStep' for Python package ('tensorflow', '1.5.1', 'https://pypi.org/simple'): 'description'
```

## This introduces a breaking change

- [x] No
