### PR TITLE
Keep pipeline run information only when adviser is run in verbose mode

### DIFF
--- a/thoth/adviser/cli.py
+++ b/thoth/adviser/cli.py
@@ -618,6 +618,7 @@ def advise(
         result_dict={"parameters": parameters},
         with_devel=dev,
         user_stack_scoring=user_stack_scoring,
+        verbose=click_ctx.parent.params.get("verbose", False),
     )
 
     click_ctx.exit(int(exit_code != 0))
@@ -903,6 +904,8 @@ def dependency_monkey(
         plot=plot,
         with_devel=dev,
         user_stack_scoring=False,
+        # Keep verbose output (stating pipeline units run) in dependency-monkey.
+        verbose=True,
     )
 
     click_ctx.exit(int(exit_code != 0))

--- a/thoth/adviser/dm_report.py
+++ b/thoth/adviser/dm_report.py
@@ -42,6 +42,6 @@ class DependencyMonkeyReport:
         """Add a new response to response listing."""
         self._responses.append({"response": response, "product": product.to_dict()})
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self, *, verbose: bool = False) -> Dict[str, Any]:
         """Convert report to a dict representation suitable for serialization."""
         return {"skipped": self.skipped, "responses": self._responses}

--- a/thoth/adviser/report.py
+++ b/thoth/adviser/report.py
@@ -85,7 +85,7 @@ class Report:
             heapq.heappush(self._heapq, item)
             return True
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self, *, verbose: bool = False) -> Dict[str, Any]:
         """Convert pipeline report to a dict representation."""
         stack_info: List[Dict[str, Any]] = []
         stack_info_metadata = os.getenv("THOTH_ADVISER_METADATA")
@@ -96,7 +96,7 @@ class Report:
                 _LOGGER.exception("Failed to load adviser metadata")
 
         return {
-            "pipeline": self.pipeline.to_dict(),
+            "pipeline": self.pipeline.to_dict() if verbose else None,
             "products": [product.to_dict() for product in self.iter_products()],
             "stack_info": stack_info + (self._stack_info or []),
             "resolver_iterations": self.resolver_iterations,

--- a/thoth/adviser/run.py
+++ b/thoth/adviser/run.py
@@ -55,6 +55,7 @@ def subprocess_run(
     plot: Optional[str] = None,
     *,
     with_devel: bool = True,
+    verbose: bool = False,
     user_stack_scoring: bool = True,
 ) -> int:
     """Run the given function (partial annealing method) in a subprocess and output the produced report."""
@@ -107,7 +108,7 @@ def subprocess_run(
                 else:
                     _LOGGER.info("Resolver history saved to %r", resolver_history_file)
 
-            result_dict.update(dict(error=False, error_msg=None, report=report.to_dict()))
+            result_dict.update(dict(error=False, error_msg=None, report=report.to_dict(verbose=verbose)))
         except UnresolvedDependencies as exc:
             _LOGGER.error(
                 "Resolver failed due to unsolved dependencies for packages %s; these dependencies will be "


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #1935

## This introduces a breaking change

- [x] No
