### PR TITLE
Introduce a mechanism for including unit based on Python packages

### DIFF
--- a/docs/source/prescription.rst
+++ b/docs/source/prescription.rst
@@ -765,6 +765,53 @@ any value on the runtime environment side is evaluated as matching.
       not:
         - package_name: git
 
+``should_include.runtime_environments.python_packages``
+#######################################################
+
+A list of Python packages that should or should *not* be present
+in the runtime environment in order to register the given pipeline unit.
+
+Information about Python package can be specified using the following fields.
+
+* ``name`` - mandatory, name of the package (e.g. ``jupyterhub``)
+
+* ``version`` - package version specifier (e.g. ``~=1.4.1``)
+
+* ``location`` - a regular expression describing where the given package should
+  be installed. An example use of this option is detecting Python packages
+  that are installed inside Python s2i environment. The regular expression is
+  matched using
+  `re.fullmatch <https://docs.python.org/3/library/re.html#re.fullmatch>`__.
+
+If ``version`` is not provided, any version present registers
+the given pipeline unit.
+
+If ``location`` is not provided, any location is considered. Note that the detection
+of Python packages does not enforce their availability on ``PYTHONPATH``.
+
+.. note::
+
+  *Example:*
+
+  .. code-block:: yaml
+
+    python_packages:
+      # Register if jupyterhub~=1.4.1 is present in s2i virtualenv
+      # and micropipenv<=1.1.0 is installed regardless of its location.
+      - name: jupyterhub
+        version: "~=1.4.1"
+        location: "^/opt/app-root/.*"
+      - name: micropipenv
+        version: <=1.1.0
+
+  .. code-block:: yaml
+
+    python_packages:
+      # Include the given pipeline unit if jupyterhub is **not** present in the
+      # runtime environment.
+      not:
+        - name: jupyterhub
+
 Boots
 =====
 

--- a/thoth/adviser/prescription/v1/schema.py
+++ b/thoth/adviser/prescription/v1/schema.py
@@ -47,6 +47,16 @@ def _with_not(entity: object) -> Schema:
     return Schema(Any(entity, Schema({"not": entity})))
 
 
+def _specifier_set(v: object) -> None:
+    """Validate a specifier set."""
+    if not isinstance(v, str):
+        raise Invalid(f"Value {v!r} is not valid version specifier (example: '<1.0>=0.5')")
+    try:
+        SpecifierSet(v)
+    except InvalidSpecifier as exc:
+        raise Invalid(str(exc))
+
+
 _RPM_PACKAGE_VERSION_SCHEMA = Schema(
     {
         Required("package_name"): _NONEMPTY_STRING,
@@ -56,6 +66,14 @@ _RPM_PACKAGE_VERSION_SCHEMA = Schema(
         Optional("package_version"): _NONEMPTY_STRING,
         Optional("release"): _NONEMPTY_STRING,
         Optional("src"): bool,
+    }
+)
+
+_PYTHON_PACKAGE_VERSION_SCHEMA = Schema(
+    {
+        Required("name"): _NONEMPTY_STRING,
+        Optional("version"): _specifier_set,
+        Optional("location"): Any(_NONEMPTY_STRING, None),
     }
 )
 
@@ -91,6 +109,7 @@ PRESCRIPTION_UNIT_SHOULD_INCLUDE_RUNTIME_ENVIRONMENTS_SCHEMA = Schema(
         Optional("base_images"): _with_not(_NONEMPTY_LIST_OF_NONEMPTY_STRINGS_WITH_NONE),
         Optional("shared_objects"): _with_not(_NONEMPTY_LIST_OF_NONEMPTY_STRINGS),
         Optional("rpm_packages"): _with_not(All([_RPM_PACKAGE_VERSION_SCHEMA], Length(min=1))),
+        Optional("python_packages"): _with_not(All([_PYTHON_PACKAGE_VERSION_SCHEMA], Length(min=1))),
     }
 )
 
@@ -208,16 +227,6 @@ PACKAGE_VERSION_LOCKED_SCHEMA = Schema(
         Optional("index_url"): Optional(_NONEMPTY_STRING),
     }
 )
-
-
-def _specifier_set(v: object) -> None:
-    """Validate a specifier set."""
-    if not isinstance(v, str):
-        raise Invalid(f"Value {v!r} is not valid version specifier (example: '<1.0>=0.5')")
-    try:
-        SpecifierSet(v)
-    except InvalidSpecifier as exc:
-        raise Invalid(str(exc))
 
 
 PACKAGE_VERSION_SCHEMA = Schema(


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/adviser/issues/1926

## This introduces a breaking change

- [x] No

## Description

With this change, we have the ability to instrument resolver to include a specific pipeline unit based on Python packages present in the runtime environment. An example can be including a specific pipeline unit to the resolution process when resolving stacks for jupyter notebooks.
