### PR TITLE
Use CLoader to load prescriptions to speed up loading

### DIFF
--- a/tests/prescription/v1/test_prescription.py
+++ b/tests/prescription/v1/test_prescription.py
@@ -18,6 +18,7 @@
 """Test implementation of prescription handling."""
 
 import pytest
+import yaml
 
 from thoth.adviser.exceptions import PrescriptionSchemaError
 from thoth.adviser.exceptions import PrescriptionDuplicateUnitNameError
@@ -70,3 +71,8 @@ class TestPrescription(AdviserTestCase):
 
         with pytest.raises(PrescriptionDuplicateUnitNameError):
             Prescription.from_dict(prescription, prescription_name="thoth", prescription_release="2021.06.15")
+
+    def test_yaml_cloader(self) -> None:
+        """Test loading using yaml.CLoader."""
+        content = yaml.load("foo: bar", Loader=yaml.CLoader)
+        assert content == {"foo": "bar"}

--- a/thoth/adviser/prescription/v1/prescription.py
+++ b/thoth/adviser/prescription/v1/prescription.py
@@ -285,7 +285,7 @@ class Prescription:
                 _LOGGER.debug("Loading prescriptions from %r", prescription)
                 with open(prescription, "r") as config_file:
                     prescription_instance = cls.from_dict(
-                        yaml.safe_load(config_file),
+                        yaml.load(config_file, Loader=yaml.CLoader),
                         prescription_instance=prescription_instance,
                         prescription_name=prescription_name,
                         prescription_release=prescription_release,


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

32MiB database of prescriptions loaded in 1.3s instead of the previous 6.4s
