### PR TITLE
TensorFlow 2.6 uses same CUDA as TensorFlow 2.5, CUDA 11.2

### DIFF
--- a/thoth/adviser/sieves/tensorflow/tf_cuda.py
+++ b/thoth/adviser/sieves/tensorflow/tf_cuda.py
@@ -58,7 +58,7 @@ class TensorFlowCUDASieve(Sieve):
     _TF_2_CUDA_10_0_SUPPORT = frozenset({(2, 0)})
     _TF_2_CUDA_10_1_SUPPORT = frozenset({(2, 1), (2, 2), (2, 3)})
     _TF_2_CUDA_11_0_SUPPORT = frozenset({(2, 4)})
-    _TF_2_CUDA_11_2_SUPPORT = frozenset({(2, 5)})
+    _TF_2_CUDA_11_2_SUPPORT = frozenset({(2, 5), (2, 6)})
     _KNOWN_CUDA = frozenset({"8", "9", "10.0", "10.1", "11.0"})
 
     # Holds tensorflow version for which a message was printed to logs.


### PR DESCRIPTION
## Related Issues and Dependencies

Based on TF SIG build call.

## This introduces a breaking change

- [x] No
