### PR TITLE
Do not add scored user stack to beam

### DIFF
--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2032,16 +2032,15 @@ class TestResolver(AdviserTestCase):
         assert resolver.beam.size == 0
 
     def test_maybe_score_user_lock_file(self, resolver: Resolver) -> None:
-        """Test scoring user stack lock file when sieves removed a package."""
+        """Test scoring user stack lock file when the lock file is accepted."""
         resolver._init_context()
 
         resolver.should_receive("_prepare_user_lock_file").and_return(None).once()
 
         assert resolver.beam.size == 0
-        resolver._maybe_score_user_lock_file()
-        assert resolver.beam.size == 1
-
-        state = resolver.beam.get(0)
+        state = resolver._maybe_score_user_lock_file()
+        assert resolver.beam.size == 0
+        assert state is not None
 
         assert state.resolved_dependencies
         assert set(state.resolved_dependencies.values()) == set(

--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -628,7 +628,6 @@ class Resolver:
             ]
         )
         self._run_wraps(state)
-        self.beam.add_state(state)
         _LOGGER.info("User's software stack has a score of %.2f - see %s", state.score, jl("user_stack"))
         return state
 


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

This is a fix when justification information is stated twice in the resulting report. We had an issue report with this, but I cannot find it.

Basically, if a user submits an advice request, we scored the user stack and kept it in the internal structure for further processing. This is, of course, not right - user's stack should be scored and no further actions are needed as the supplied stack is already resolved.
