### PR TITLE
Make wrap match part optional

### DIFF
--- a/thoth/adviser/prescription/v1/schema.py
+++ b/thoth/adviser/prescription/v1/schema.py
@@ -444,7 +444,7 @@ PRESCRIPTION_STRIDE_SCHEMA = Schema(
 #
 
 PRESCRIPTION_WRAP_MATCH_ENTRY_SCHEMA = Schema(
-    {Required("state"): Schema({Required("resolved_dependencies"): [PACKAGE_VERSION_SCHEMA]})}
+    {Optional("state"): Schema({Required("resolved_dependencies"): [PACKAGE_VERSION_SCHEMA]})}
 )
 
 PRESCRIPTION_WRAP_RUN_SCHEMA = Schema(

--- a/thoth/adviser/prescription/v1/wrap.py
+++ b/thoth/adviser/prescription/v1/wrap.py
@@ -26,8 +26,9 @@ from typing import TYPE_CHECKING
 
 from thoth.adviser.state import State
 from voluptuous import Any as SchemaAny
-from voluptuous import Schema
+from voluptuous import Optional
 from voluptuous import Required
+from voluptuous import Schema
 
 from .unit import UnitPrescription
 from .schema import PRESCRIPTION_WRAP_MATCH_ENTRY_SCHEMA
@@ -44,7 +45,7 @@ class WrapPrescription(UnitPrescription):
     CONFIGURATION_SCHEMA: Schema = Schema(
         {
             Required("package_name"): SchemaAny(str, None),
-            Required("match"): PRESCRIPTION_WRAP_MATCH_ENTRY_SCHEMA,
+            Optional("match"): PRESCRIPTION_WRAP_MATCH_ENTRY_SCHEMA,
             Required("run"): PRESCRIPTION_WRAP_RUN_SCHEMA,
         }
     )


### PR DESCRIPTION
## Related Issues and Dependencies

```
2021-07-30 11:04:50,574 85598 DEBUG    thoth.adviser.unit:157: Validating configuration for pipeline unit 'thoth.ThothBaseImageWrap'
2021-07-30 11:04:50,574 85598 ERROR    thoth.adviser.unit:161: Failed to validate schema for pipeline unit 'thoth.ThothBaseImageWrap': required key not provided @ data['match']['state']
Traceback (most recent call last):
  File "/home/fpokorny/git/thoth-station/adviser/thoth/adviser/unit.py", line 159, in update_configuration
    self.CONFIGURATION_SCHEMA(self.configuration)
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 594, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 432, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: required key not provided @ data['match']['state']
2021-07-30 11:04:50,575 85598 CRITICAL root:105: Traceback (most recent call last):
  File "/home/fpokorny/git/thoth-station/adviser/thoth/adviser/unit.py", line 159, in update_configuration
    self.CONFIGURATION_SCHEMA(self.configuration)
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 594, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/home/fpokorny/.local/share/virtualenvs/adviser-1eaKppR3/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 432, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: required key not provided @ data['match']['state']
```

## This introduces a breaking change

- [x] No
