### PR TITLE
Fix pre-commit complains

### DIFF
--- a/thoth/adviser/cli.py
+++ b/thoth/adviser/cli.py
@@ -937,7 +937,7 @@ def validate_prescription(prescriptions: str, show_unit_names: bool) -> None:
             "strides_count": sum(1 for _ in prescription.iter_stride_units()),
             "wraps_count": sum(1 for _ in prescription.iter_wrap_units()),
         },
-        "count_all": sum(1 for _ in prescription.units)
+        "count_all": sum(1 for _ in prescription.units),
     }
 
     if show_unit_names:

--- a/thoth/adviser/prescription/v1/pseudonym.py
+++ b/thoth/adviser/prescription/v1/pseudonym.py
@@ -23,7 +23,6 @@ from typing import Dict
 from typing import Generator
 from typing import Optional
 from typing import Tuple
-from typing import Union
 from typing import TYPE_CHECKING
 
 from thoth.python import PackageVersion

--- a/thoth/adviser/prescription/v1/sieve.py
+++ b/thoth/adviser/prescription/v1/sieve.py
@@ -21,7 +21,6 @@ from typing import Any
 from typing import Dict
 from typing import Generator
 from typing import Optional
-from typing import Union
 from typing import TYPE_CHECKING
 import logging
 

--- a/thoth/adviser/prescription/v1/step.py
+++ b/thoth/adviser/prescription/v1/step.py
@@ -24,7 +24,6 @@ from typing import Generator
 from typing import List
 from typing import Optional
 from typing import Tuple
-from typing import Union
 from typing import TYPE_CHECKING
 import logging
 


### PR DESCRIPTION
## This introduces a breaking change

```
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted /home/fpokorny/git/thoth-station/adviser/thoth/adviser/cli.py
All done! ✨ 🍰 ✨
1 file reformatted, 217 files left unchanged.

flake8...................................................................Failed
- hook id: flake8
- exit code: 1

thoth/adviser/prescription/v1/pseudonym.py:26:1: F401 'typing.Union' imported but unused
thoth/adviser/prescription/v1/sieve.py:24:1: F401 'typing.Union' imported but unused
thoth/adviser/prescription/v1/step.py:27:1: F401 'typing.Union' imported but unused
```