### PR TITLE
Be less verbose about cache hits in prescription unit cache

### DIFF
--- a/thoth/adviser/prescription/v1/unit_cache.py
+++ b/thoth/adviser/prescription/v1/unit_cache.py
@@ -46,7 +46,7 @@ def should_include_cache(func: "SHOULD_INCLUDE_FUNC_TYPE") -> "SHOULD_INCLUDE_FU
     ) -> bool:
         cached_result = cls.SHOULD_INCLUDE_CACHE.get(unit_name)
         if cached_result is not None:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "%s: Using pre-cached result (%r) of should include prescription part", unit_name, cached_result
             )
             return cached_result


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

These messages are not important to users, they should be used only on debug.