### PR TITLE
Use local import for matplotlib

### DIFF
--- a/thoth/adviser/beam.py
+++ b/thoth/adviser/beam.py
@@ -23,18 +23,19 @@ from typing import List
 from typing import Tuple
 from typing import Generator
 from typing import Optional
+from typing import TYPE_CHECKING
 import logging
 
 from fext import ExtHeapQueue
-import matplotlib
-import matplotlib.pyplot as plt
-from matplotlib.font_manager import FontProperties
 
 import attr
 
 from .exceptions import NoHistoryKept
 from .state import State
 from .utils import should_keep_history
+
+if TYPE_CHECKING:
+    import matplotlib
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -112,10 +113,13 @@ class Beam:
         for sp in ax.spines.values():
             sp.set_visible(False)
 
-    def plot(self) -> matplotlib.figure.Figure:
+    def plot(self) -> "matplotlib.figure.Figure":
         """Plot temperature history of adaptive simulated annealing."""
         if not self._beam_history:
             raise NoHistoryKept("No history datapoints kept for beam")
+
+        import matplotlib.pyplot as plt
+        from matplotlib.font_manager import FontProperties
 
         x = [i for i in range(len(self._beam_history))]
         # Beam size over time.

--- a/thoth/adviser/dependency_monkey.py
+++ b/thoth/adviser/dependency_monkey.py
@@ -24,11 +24,11 @@ import logging
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import TYPE_CHECKING
 from functools import partial
 
 import attr
 import amun
-import matplotlib
 from thoth.python import Project
 
 from .beam import Beam
@@ -36,6 +36,9 @@ from .dm_report import DependencyMonkeyReport
 from .predictor import Predictor
 from .resolver import Resolver
 from .enums import DecisionType
+
+if TYPE_CHECKING:
+    import matplotlib
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,7 +64,7 @@ class DependencyMonkey:
         """Get beam instance used in the resolver."""
         return self.resolver.beam
 
-    def plot(self) -> matplotlib.figure.Figure:
+    def plot(self) -> "matplotlib.figure.Figure":
         """Plot info from Dependency Monkey run."""
         return self.resolver.plot()
 

--- a/thoth/adviser/predictor.py
+++ b/thoth/adviser/predictor.py
@@ -26,13 +26,16 @@ from typing import Any
 from typing import Tuple
 from typing import Optional
 from typing import Generator
-
-import matplotlib.figure
+from typing import TYPE_CHECKING
 
 from .context import Context
 from .report import Report
 from .state import State
 from .utils import should_keep_history
+
+if TYPE_CHECKING:
+    import matplotlib.figure
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -113,7 +116,7 @@ class Predictor:
         """
         # noop
 
-    def plot(self) -> matplotlib.figure.Figure:
+    def plot(self) -> "matplotlib.figure.Figure":
         """Plot information about predictor."""
         _LOGGER.error(
             "Cannot plot predictor history as plotting is not implemented for predictor %r, error is not fatal",

--- a/thoth/adviser/predictors/annealing.py
+++ b/thoth/adviser/predictors/annealing.py
@@ -21,20 +21,20 @@ from typing import Any
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import TYPE_CHECKING
 import logging
 import random
 import math
 
 import attr
-import matplotlib
-import matplotlib.pyplot as plt
-from matplotlib.font_manager import FontProperties
 
 from ..context import Context
 from ..exceptions import NoHistoryKept
 from ..predictor import Predictor
 from ..state import State
 
+if TYPE_CHECKING:
+    import matplotlib
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -141,13 +141,15 @@ class AdaptiveSimulatedAnnealing(Predictor):
         for sp in ax.spines.values():
             sp.set_visible(False)
 
-    def plot(self) -> matplotlib.figure.Figure:
+    def plot(self) -> "matplotlib.figure.Figure":
         """Plot temperature history of adaptive simulated annealing."""
         # Code adjusted based on:
         #    https://matplotlib.org/3.1.1/gallery/ticks_and_spines/multiple_yaxis_with_spines.html
-
         if self._temperature_history is None:
             raise NoHistoryKept("No history datapoints kept")
+
+        import matplotlib.pyplot as plt
+        from matplotlib.font_manager import FontProperties
 
         x = [i for i in range(len(self._temperature_history))]
         # Top rated candidate was chosen.

--- a/thoth/adviser/predictors/hill_climbing.py
+++ b/thoth/adviser/predictors/hill_climbing.py
@@ -22,14 +22,14 @@ import logging
 import attr
 from typing import List
 from typing import Tuple
-
-import matplotlib
-import matplotlib.pyplot as plt
-from matplotlib.font_manager import FontProperties
+from typing import TYPE_CHECKING
 
 from ..predictor import Predictor
 from ..state import State
 from ..exceptions import NoHistoryKept
+
+if TYPE_CHECKING:
+    import matplotlib
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,10 +54,13 @@ class HillClimbing(Predictor):
         """Initialize before the actual hill climbing run."""
         self._history = []
 
-    def plot(self) -> matplotlib.figure.Figure:
+    def plot(self) -> "matplotlib.figure.Figure":
         """Plot score of the highest rated stack during hill climbing."""
         if not self._history:
             raise NoHistoryKept("No history datapoints kept")
+
+        import matplotlib.pyplot as plt
+        from matplotlib.font_manager import FontProperties
 
         x = [i for i in range(len(self._history))]
         y1 = [i[0] for i in self._history]

--- a/thoth/adviser/predictors/random_walk.py
+++ b/thoth/adviser/predictors/random_walk.py
@@ -22,14 +22,14 @@ import logging
 import attr
 from typing import List
 from typing import Tuple
-
-import matplotlib
-import matplotlib.pyplot as plt
-from matplotlib.font_manager import FontProperties
+from typing import TYPE_CHECKING
 
 from ..predictor import Predictor
 from ..state import State
 from ..exceptions import NoHistoryKept
+
+if TYPE_CHECKING:
+    import matplotlib
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,10 +65,13 @@ class RandomWalk(Predictor):
         """Initialize before the random walk run."""
         self._history = []
 
-    def plot(self) -> matplotlib.figure.Figure:
+    def plot(self) -> "matplotlib.figure.Figure":
         """Plot score of the highest rated stack during sampling."""
         if not self._history:
             raise NoHistoryKept("No history datapoints kept")
+
+        import matplotlib.pyplot as plt
+        from matplotlib.font_manager import FontProperties
 
         x = [i for i in range(len(self._history))]
         y1 = [i[0] for i in self._history]

--- a/thoth/adviser/predictors/sampling.py
+++ b/thoth/adviser/predictors/sampling.py
@@ -22,14 +22,14 @@ import logging
 import attr
 from typing import List
 from typing import Tuple
-
-import matplotlib
-import matplotlib.pyplot as plt
-from matplotlib.font_manager import FontProperties
+from typing import TYPE_CHECKING
 
 from ..predictor import Predictor
 from ..state import State
 from ..exceptions import NoHistoryKept
+
+if TYPE_CHECKING:
+    import matplotlib
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,10 +54,13 @@ class Sampling(Predictor):
         """Initialize before the sampling run."""
         self._history = []
 
-    def plot(self) -> matplotlib.figure.Figure:
+    def plot(self) -> "matplotlib.figure.Figure":
         """Plot score of the highest rated stack during sampling."""
         if not self._history:
             raise NoHistoryKept("No history datapoints kept")
+
+        import matplotlib.pyplot as plt
+        from matplotlib.font_manager import FontProperties
 
         x = [i for i in range(len(self._history))]
         y1 = [i[0] for i in self._history]

--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -38,9 +38,6 @@ import weakref
 import heapq
 
 import attr
-import matplotlib
-import matplotlib.pyplot as plt
-from matplotlib.font_manager import FontProperties
 from thoth.common import get_justification_link as jl
 from thoth.python import PackageVersion
 from thoth.python import Project
@@ -75,6 +72,7 @@ from .unit import Unit
 from .utils import log_once
 
 if TYPE_CHECKING:
+    import matplotlib
     from .prescription import Prescription  # noqa: F401
 
 
@@ -1359,10 +1357,13 @@ class Resolver:
 
             return report
 
-    def plot(self) -> matplotlib.figure.Figure:
+    def plot(self) -> "matplotlib.figure.Figure":
         """Plot history captured during the resolution process."""
         if not self._history:
             raise NoHistoryKept("No history datapoints kept")
+
+        import matplotlib.pyplot as plt
+        from matplotlib.font_manager import FontProperties
 
         x = [i for i in range(len(self._history))]
         y1 = self._history


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thamos/issues/914

## This introduces a breaking change

- [x] No

## Description

matplotlib performs initialization on import. As we do not use it in the prod setup, let's move imports of matplotlib (that are used for debugging purposes) and trigger import only if plotting adviser's progress.