### PR TITLE
Point users to support repository to request analyses of packages

### DIFF
--- a/thoth/adviser/exceptions.py
+++ b/thoth/adviser/exceptions.py
@@ -145,9 +145,9 @@ class UnresolvedDependencies(AdviserRunException):  # noqa: N818
         """Convert unresolved dependencies exception to the user."""
         return {
             "ERROR": "No dependencies found for "
-            f"{', '.join(f'{dep!r}' for dep in self.unresolved)}  - these "
-            "dependencies were not yet solved in Thoth "
-            "cannot resolve all direct dependencies",
+            f"{', '.join(f'{dep!r}' for dep in self.unresolved)}: these "
+            "dependencies were not yet analyzed in Thoth - "
+            "visit https://tinyurl.com/thoth-unresolved to request analyses",
             "_ERROR_DETAILS": {
                 "unresolved": self.unresolved,
             },

--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -697,6 +697,15 @@ class Resolver:
                 )
                 _LOGGER.warning("%s - see %s", error_msg, jl("unresolved"))
 
+            self.context.stack_info.append(
+                {
+                    "message": "Visit thoth-station/support repository and request analyses of unresolved packages "
+                    "to have them available in recommendations",
+                    "link": "https://tinyurl.com/thoth-unresolved",
+                    "type": "INFO",
+                }
+            )
+
             raise UnresolvedDependencies(
                 "Unable to resolve all direct dependencies", unresolved=unresolved, stack_info=self.context.stack_info
             )

--- a/thoth/adviser/run.py
+++ b/thoth/adviser/run.py
@@ -111,8 +111,7 @@ def subprocess_run(
             result_dict.update(dict(error=False, error_msg=None, report=report.to_dict(verbose=verbose)))
         except UnresolvedDependencies as exc:
             _LOGGER.error(
-                "Resolver failed due to unsolved dependencies for packages %s; these dependencies will be "
-                "automatically marked for solving by the system for future resolutions",
+                "Resolver failed due to unsolved dependencies for packages %s",
                 ", ".join(exc.unresolved),
             )
             return_code = 2  # If forked, do not overwrite results by parent process.


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/adviser/issues/2130

## This introduces a breaking change

- [x] No

## Description

Let's point users to thoth-station/support repository to request including a package. As of now, we do it for all the requests explicitly (authenticated and unauthenticated).
