### PR TITLE
Introduce a CVE sieve

### DIFF
--- a/tests/sieves/test_cve.py
+++ b/tests/sieves/test_cve.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test filtering based on a CVE."""
+
+import pytest
+
+from thoth.adviser.context import Context
+from thoth.adviser.enums import RecommendationType
+from thoth.adviser.pipeline_builder import PipelineBuilderContext
+from thoth.adviser.sieves import CveSieve
+from thoth.common import get_justification_link as jl
+from thoth.python import PackageVersion
+from thoth.python import Source
+
+from ..base import AdviserUnitTestCase
+
+
+class TestCveSieve(AdviserUnitTestCase):
+    """Test filtering based on a CVE."""
+
+    UNIT_TESTED = CveSieve
+
+    _CASE_CANDIDATES = [
+        ("flask", "0.12.0", "https://pypi.org/simple"),
+        ("click", "2.0", "https://pypi.org/simple"),
+        ("pyyaml", "3.12", "https://pypi.org/simple"),
+    ]
+
+    _FLASK_CVE = {
+        "details": "flask version Before 0.12.3 contains a CWE-20: Improper Input Validation "
+        "vulnerability in flask that can result in Large amount of memory usage "
+        "possibly leading to denial of service.",
+        "cve_id": "CVE-ID",
+        "aggregated_at": "2021-06-02T08:23:17.11783Z",
+    }
+
+    def test_verify_multiple_should_include(self, builder_context: PipelineBuilderContext) -> None:
+        """Verify multiple should_include calls do not loop endlessly."""
+        builder_context.recommendation_type = RecommendationType.SECURITY
+        self.verify_multiple_should_include(builder_context)
+
+    @pytest.mark.parametrize(
+        "recommendation_type",
+        [
+            RecommendationType.LATEST,
+            RecommendationType.STABLE,
+            RecommendationType.PERFORMANCE,
+            RecommendationType.TESTING,
+        ],
+    )
+    def test_should_include_recommendation_type(
+        self, builder_context: PipelineBuilderContext, recommendation_type: RecommendationType
+    ):
+        """Check not including the given pipeline unit for recommendations other than SECURITY."""
+        builder_context.recommendation_type = recommendation_type
+        builder_context.decision_type = None
+        assert list(self.UNIT_TESTED.should_include(builder_context)) == []
+
+    def test_cve_sieve(self, context: Context) -> None:
+        """Make sure a CVE filters out packages."""
+        context.graph.should_receive("get_python_cve_records_all").with_args(
+            package_name="flask", package_version="0.12.0"
+        ).and_return([self._FLASK_CVE])
+
+        context.graph.should_receive("get_python_cve_records_all").with_args(
+            package_name="flask", package_version="1.0.0"
+        ).and_return([])
+
+        pv1 = PackageVersion(
+            name="flask",
+            version="==0.12.0",
+            index=Source("https://pypi.org/simple"),
+            develop=False,
+        )
+
+        pv2 = PackageVersion(
+            name="flask",
+            version="==1.0.0",
+            index=Source("https://pypi.org/simple"),
+            develop=False,
+        )
+
+        assert not context.stack_info
+
+        context.recommendation_type = RecommendationType.SECURITY
+
+        with self.UNIT_TESTED.assigned_context(context):
+            unit = self.UNIT_TESTED()
+            result = list(unit.run((pv for pv in (pv1, pv2))))
+
+        assert result is not None
+        assert result == [pv2]
+        assert context.stack_info == [
+            {
+                "link": jl("cve"),
+                "message": "Skipping including package ('flask', '0.12.0', "
+                "'https://pypi.org/simple') as a CVE 'CVE-ID' was found",
+                "type": "WARNING",
+            }
+        ]
+        assert self.verify_justification_schema(context.stack_info)

--- a/thoth/adviser/sieves/__init__.py
+++ b/thoth/adviser/sieves/__init__.py
@@ -17,6 +17,7 @@
 
 """Implementation of sieves used in adviser pipeline."""
 
+from .cve import CveSieve
 from .constraints import ConstraintsSieve
 from .experimental_filter_conf_index import FilterConfiguredIndexSieve
 from .experimental_package_index import PackageIndexConfigurationSieve
@@ -45,6 +46,7 @@ __all__ = [
     "ConstraintsSieve",
     "SelectiveCutPreReleasesSieve",
     "FilterConfiguredIndexSieve",
+    "CveSieve",
     "PackageCombinationsSieve",
     "PackageIndexConfigurationSieve",
     "CutLockedSieve",

--- a/thoth/adviser/sieves/cve.py
+++ b/thoth/adviser/sieves/cve.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Sieve packages with CVE when recommendation type is set to security."""
+
+import logging
+
+from typing import Any
+from typing import Dict
+from typing import Generator
+from typing import Set
+from typing import Tuple
+from typing import TYPE_CHECKING
+
+import attr
+from thoth.common import get_justification_link as jl
+from thoth.python import PackageVersion
+from thoth.storages.exceptions import NotFoundError
+from voluptuous import Required
+from voluptuous import Schema
+
+from ..enums import RecommendationType
+from ..sieve import Sieve
+
+if TYPE_CHECKING:
+    from ..pipeline_builder import PipelineBuilderContext
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@attr.s(slots=True)
+class CveSieve(Sieve):
+    """Filter out packages with CVEs."""
+
+    CONFIGURATION_DEFAULT = {"package_name": None}
+    CONFIGURATION_SCHEMA: Schema = Schema(
+        {
+            Required("package_name"): None,
+        }
+    )
+    _JUSTIFICATION_LINK = jl("cve")
+
+    _messages_logged = attr.ib(type=Set[Tuple[str, str, str]], factory=set, init=False)
+
+    @classmethod
+    def should_include(cls, builder_context: "PipelineBuilderContext") -> Generator[Dict[str, Any], None, None]:
+        """Remove CVEs only secure stacks."""
+        if (
+            builder_context.is_adviser_pipeline()
+            and not builder_context.is_included(cls)
+            and builder_context.recommendation_type == RecommendationType.SECURITY
+        ):
+            yield {}
+            return None
+
+        yield from ()
+        return None
+
+    def pre_run(self) -> None:
+        """Initialize this pipeline unit before running."""
+        self._messages_logged.clear()
+        super().pre_run()
+
+    def run(self, package_versions: Generator[PackageVersion, None, None]) -> Generator[PackageVersion, None, None]:
+        """Filter out packages with a CVE."""
+        for package_version in package_versions:
+            try:
+                cve_records = self.context.graph.get_python_cve_records_all(
+                    package_name=package_version.name,
+                    package_version=package_version.locked_version,
+                )
+            except NotFoundError as exc:
+                _LOGGER.warning("Package %r in version %r not found: %r", exc)
+                continue
+
+            if not cve_records:
+                yield package_version
+                continue
+
+            package_version_tuple = package_version.to_tuple()
+            _LOGGER.debug("Found a CVEs for %r: %r", package_version_tuple, cve_records)
+
+            if package_version_tuple not in self._messages_logged:
+                self._messages_logged.add(package_version_tuple)
+                for cve_record in cve_records:
+                    message = (
+                        f"Skipping including package {package_version_tuple!r} as a CVE "
+                        f"{cve_record['cve_id']!r} was found"
+                    )
+                    _LOGGER.warning(message)
+                    self.context.stack_info.append(
+                        {"type": "WARNING", "message": message, "link": self._JUSTIFICATION_LINK}
+                    )


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

With this change, packages with CVEs will be filtered out sooner in the resolution process. This will make sure the security-based recommendations will be more optimal when finding a software stack without any security vulnerabilities.
