### PR TITLE
Provide information about last CVE update to users

### DIFF
--- a/tests/boots/test_cve_timestamp.py
+++ b/tests/boots/test_cve_timestamp.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""A boot to provide information about the last CVE update."""
+
+import pytest
+
+from datetime import datetime
+from datetime import timedelta
+
+from thoth.adviser.boots import CveTimestampBoot
+from thoth.adviser.context import Context
+from thoth.adviser.pipeline_builder import PipelineBuilderContext
+from thoth.adviser.enums import RecommendationType
+from thoth.common import datetime2datetime_str
+from thoth.common import get_justification_link as jl
+from ..base import AdviserUnitTestCase
+
+
+class TestCveTimestampBoot(AdviserUnitTestCase):
+    """Test providing information about the last CVE update."""
+
+    UNIT_TESTED = CveTimestampBoot
+
+    def test_verify_multiple_should_include(self) -> None:
+        """Verify multiple should_include calls do not loop endlessly."""
+        builder_context = PipelineBuilderContext(recommendation_type=RecommendationType.LATEST)
+        self.verify_multiple_should_include(builder_context)
+
+    def test_should_include(self, builder_context: PipelineBuilderContext) -> None:
+        """Test registering this unit for adviser runs."""
+        assert list(self.UNIT_TESTED.should_include(builder_context)) == [{}]
+
+        builder_context.add_unit(self.UNIT_TESTED())
+
+        assert list(self.UNIT_TESTED.should_include(builder_context)) == []
+
+    @pytest.mark.parametrize(
+        "timestamp,type_severity",
+        [(datetime.utcnow() - timedelta(days=1), "INFO"), (datetime.utcnow() - timedelta(days=1000), "WARNING")],
+    )
+    def test_run_info(self, context: Context, timestamp: datetime, type_severity: str) -> None:
+        """Test providing CVE update timestamp to users."""
+        context.graph.should_receive("get_cve_timestamp").and_return(timestamp).once()
+        unit = self.UNIT_TESTED()
+
+        assert not context.stack_info
+        with unit.assigned_context(context):
+            unit.run()
+
+        assert len(context.stack_info) == 1
+        assert set(context.stack_info[0]) == {"link", "message", "type"}
+        assert self.verify_justification_schema(context.stack_info)
+        assert context.stack_info[0]["link"] == jl("cve_timestamp")
+        assert (
+            context.stack_info[0]["message"] == f"CVE database of known vulnerabilities for Python packages "
+            f"was updated at {datetime2datetime_str(timestamp)!r}"
+        )
+        assert context.stack_info[0]["type"] == type_severity
+
+    def test_run_no_cve_timestamp(self, context: Context) -> None:
+        """Test warning if CVE timestamp is not recorded in the database."""
+        context.graph.should_receive("get_cve_timestamp").and_return(None).once()
+        unit = self.UNIT_TESTED()
+
+        assert not context.stack_info
+        with unit.assigned_context(context):
+            unit.run()
+
+        assert len(context.stack_info) == 1
+        assert set(context.stack_info[0]) == {"link", "message", "type"}
+        assert self.verify_justification_schema(context.stack_info)
+        assert context.stack_info[0] == {
+            "link": jl("no_cve_timestamp"),
+            "message": "No CVE timestamp information found in the database",
+            "type": "WARNING",
+        }

--- a/thoth/adviser/boots/__init__.py
+++ b/thoth/adviser/boots/__init__.py
@@ -17,6 +17,7 @@
 
 """Boot units implemented in adviser."""
 
+from .cve_timestamp import CveTimestampBoot
 from .fully_specified_environment import FullySpecifiedEnvironment
 from .gpu import GPUBoot
 from .labels import LabelsBoot
@@ -40,6 +41,7 @@ from .ubi import UbiBoot
 # can be mentioned here.
 __all__ = [
     # "MemTraceBoot",
+    "CveTimestampBoot",
     "LabelsBoot",
     "PipfileHashBoot",  # Should be placed before any changes to the input.
     "GPUBoot",  # Should be placed before any GPU specific pipeline unit.

--- a/thoth/adviser/boots/cve_timestamp.py
+++ b/thoth/adviser/boots/cve_timestamp.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""A boot to provide information about the last CVE update."""
+
+import logging
+import os
+from datetime import datetime
+from typing import Any
+from typing import Dict
+from typing import Generator
+from typing import TYPE_CHECKING
+
+import attr
+from thoth.common import datetime2datetime_str
+from thoth.common import get_justification_link as jl
+
+from ..boot import Boot
+
+if TYPE_CHECKING:
+    from ..pipeline_builder import PipelineBuilderContext
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@attr.s(slots=True)
+class CveTimestampBoot(Boot):
+    """A boot to provide information about the last CVE update."""
+
+    _CVE_TIMESTAMP_DAYS_WARNING = int(os.getenv("THOTH_ADVISER_CVE_TIMESTAMP_DAYS_WARNING", 7))
+
+    @classmethod
+    def should_include(cls, builder_context: "PipelineBuilderContext") -> Generator[Dict[str, Any], None, None]:
+        """Register self, once, always."""
+        if builder_context.is_adviser_pipeline() and not builder_context.is_included(cls):
+            yield {}
+            return None
+
+        yield from ()
+        return None
+
+    def run(self) -> None:
+        """Check CVE timestamp and provide it to users."""
+        cve_timestamp = self.context.graph.get_cve_timestamp()
+        if cve_timestamp is None:
+            message = "No CVE timestamp information found in the database"
+            self.context.stack_info.append(
+                {
+                    "message": message,
+                    "type": "WARNING",
+                    "link": jl("no_cve_timestamp"),
+                }
+            )
+            return
+
+        days = (datetime.utcnow() - cve_timestamp).days
+        self.context.stack_info.append(
+            {
+                "type": "WARNING" if days > self._CVE_TIMESTAMP_DAYS_WARNING else "INFO",
+                "message": f"CVE database of known vulnerabilities for Python packages was "
+                f"updated at {datetime2datetime_str(cve_timestamp)!r}",
+                "link": jl("cve_timestamp"),
+            }
+        )


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/adviser/issues/2142

## This introduces a breaking change

- [x] No

## Description

Users of Thoth will have information about the last CVE update so that they are aware how old the CVE information provided is.