### PR TITLE
Fix matching operating system in prescriptions

### DIFF
--- a/tests/prescription/v1/test_unit.py
+++ b/tests/prescription/v1/test_unit.py
@@ -395,7 +395,7 @@ class TestUnitPrescription(AdviserTestCase):
             (
                 {"operating_systems": [{"name": "rhel"}]},
                 {"operating_system": {"name": "rhel", "version": "8"}},
-                False,
+                True,
             ),
             # CPU/GPU.
             (

--- a/thoth/adviser/prescription/v1/unit.py
+++ b/thoth/adviser/prescription/v1/unit.py
@@ -422,7 +422,9 @@ class UnitPrescription(Unit, metaclass=abc.ABCMeta):
             for item in operating_systems:
                 os_name = item.get("name")
                 os_version = item.get("version")
-                if os_name == os_used_name and os_version == os_used_version:
+                if (os_name is None or os_name == os_used_name) and (
+                    os_version is None or os_version == os_used_version
+                ):
                     _LOGGER.debug("%s: Matching operating system %r in version %r", unit_name, os_name, os_version)
                     break
             else:


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

For example, the following prescription:

```yaml
runtime_environments:
  operating_systems:
  - name: rhel
```

should match:

```yaml
runtime_environment:
  operating_system:
    name: rhel
    version: "8"
```
