### PR TITLE
Adjust flexmock import to respect new flexmock release notes

### DIFF
--- a/tests/boots/test_python_version.py
+++ b/tests/boots/test_python_version.py
@@ -17,7 +17,7 @@
 
 """Test boot for Python version assignment."""
 
-import flexmock
+from flexmock import flexmock
 
 from thoth.adviser.boots import PythonVersionBoot
 from thoth.adviser.enums import RecommendationType

--- a/tests/boots/test_rhel_version.py
+++ b/tests/boots/test_rhel_version.py
@@ -17,7 +17,7 @@
 
 """Test changes to RHEL version for major RHEL releases."""
 
-import flexmock
+from flexmock import flexmock
 
 from thoth.adviser.boots import RHELVersionBoot
 from thoth.adviser.pipeline_builder import PipelineBuilderContext

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@
 from typing import Callable
 
 import pytest
-import flexmock
+from flexmock import flexmock
 
 from thoth.adviser.context import Context
 from thoth.adviser.beam import Beam

--- a/tests/predictors/test_annealing.py
+++ b/tests/predictors/test_annealing.py
@@ -19,7 +19,7 @@
 
 from typing import Callable
 
-import flexmock
+from flexmock import flexmock
 
 from hypothesis import given
 from hypothesis.strategies import integers

--- a/tests/predictors/test_hill_climbing.py
+++ b/tests/predictors/test_hill_climbing.py
@@ -19,7 +19,7 @@
 
 from typing import Callable
 
-import flexmock
+from flexmock import flexmock
 from hypothesis import given
 from hypothesis.strategies import integers
 

--- a/tests/predictors/test_latest.py
+++ b/tests/predictors/test_latest.py
@@ -19,7 +19,7 @@
 
 from typing import Callable
 
-import flexmock
+from flexmock import flexmock
 from hypothesis import given
 from hypothesis.strategies import integers
 

--- a/tests/predictors/test_mcts.py
+++ b/tests/predictors/test_mcts.py
@@ -19,7 +19,7 @@
 
 import math
 
-import flexmock
+from flexmock import flexmock
 import pytest
 
 from thoth.adviser.context import Context

--- a/tests/predictors/test_random_walk.py
+++ b/tests/predictors/test_random_walk.py
@@ -19,7 +19,7 @@
 
 from typing import Callable
 
-import flexmock
+from flexmock import flexmock
 from hypothesis import given
 from hypothesis.strategies import integers
 

--- a/tests/predictors/test_sampling.py
+++ b/tests/predictors/test_sampling.py
@@ -19,7 +19,7 @@
 
 from typing import Callable
 
-import flexmock
+from flexmock import flexmock
 from hypothesis import given
 from hypothesis.strategies import integers
 

--- a/tests/predictors/test_td.py
+++ b/tests/predictors/test_td.py
@@ -23,7 +23,7 @@ import random
 from hypothesis import given
 from hypothesis.strategies import floats
 from hypothesis.strategies import integers
-import flexmock
+from flexmock import flexmock
 import pytest
 
 from thoth.adviser.context import Context

--- a/tests/prescription/v1/test_boot.py
+++ b/tests/prescription/v1/test_boot.py
@@ -19,7 +19,7 @@
 
 from typing import Optional
 
-import flexmock
+from flexmock import flexmock
 import pytest
 import yaml
 

--- a/tests/prescription/v1/test_gh_release_notes.py
+++ b/tests/prescription/v1/test_gh_release_notes.py
@@ -19,7 +19,7 @@
 
 from typing import Generator
 
-import flexmock
+from flexmock import flexmock
 import pytest
 import yaml
 

--- a/tests/prescription/v1/test_pseudonym.py
+++ b/tests/prescription/v1/test_pseudonym.py
@@ -19,7 +19,7 @@
 
 from typing import Optional
 
-import flexmock
+from flexmock import flexmock
 import pytest
 import yaml
 

--- a/tests/prescription/v1/test_sieve.py
+++ b/tests/prescription/v1/test_sieve.py
@@ -17,7 +17,7 @@
 
 """Test implementation of sieve prescription v1."""
 
-import flexmock
+from flexmock import flexmock
 import pytest
 import yaml
 

--- a/tests/prescription/v1/test_step.py
+++ b/tests/prescription/v1/test_step.py
@@ -17,7 +17,7 @@
 
 """Test implementation of step prescription v1."""
 
-import flexmock
+from flexmock import flexmock
 import pytest
 import yaml
 

--- a/tests/prescription/v1/test_stride.py
+++ b/tests/prescription/v1/test_stride.py
@@ -17,7 +17,7 @@
 
 """Test implementation of stride prescription v1."""
 
-import flexmock
+from flexmock import flexmock
 import pytest
 import yaml
 

--- a/tests/prescription/v1/test_unit.py
+++ b/tests/prescription/v1/test_unit.py
@@ -23,7 +23,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-import flexmock
+from flexmock import flexmock
 import pytest
 
 from thoth.adviser.enums import RecommendationType

--- a/tests/prescription/v1/test_wrap.py
+++ b/tests/prescription/v1/test_wrap.py
@@ -17,7 +17,7 @@
 
 """Test implementation of wrap prescription v1."""
 
-import flexmock
+from flexmock import flexmock
 import pytest
 import yaml
 

--- a/tests/sieves/test_index_enabled.py
+++ b/tests/sieves/test_index_enabled.py
@@ -17,7 +17,7 @@
 
 """Test filtering out packages based on enabled or disabled Python package index."""
 
-import flexmock
+from flexmock import flexmock
 
 from thoth.adviser.enums import RecommendationType
 from thoth.adviser.pipeline_builder import PipelineBuilderContext

--- a/tests/sieves/test_locked.py
+++ b/tests/sieves/test_locked.py
@@ -17,7 +17,7 @@
 
 """Test removing pinned versions in direct dependencies."""
 
-import flexmock
+from flexmock import flexmock
 
 from thoth.adviser.enums import RecommendationType
 from thoth.adviser.pipeline_builder import PipelineBuilderContext

--- a/tests/sieves/test_prereleases.py
+++ b/tests/sieves/test_prereleases.py
@@ -17,7 +17,7 @@
 
 """Test removing pre-releases in direct dependencies."""
 
-import flexmock
+from flexmock import flexmock
 import pytest
 
 from thoth.adviser.sieves import CutPreReleasesSieve

--- a/tests/sieves/test_solved.py
+++ b/tests/sieves/test_solved.py
@@ -17,7 +17,7 @@
 
 """Tests related to filtering out unsolved packages and packages with build-time error (installation issues)."""
 
-import flexmock
+from flexmock import flexmock
 from typing import Tuple
 
 from thoth.adviser.enums import RecommendationType

--- a/tests/sieves/test_thoth_s2i_abi_compat.py
+++ b/tests/sieves/test_thoth_s2i_abi_compat.py
@@ -19,7 +19,7 @@
 
 from typing import Optional
 
-import flexmock
+from flexmock import flexmock
 import pytest
 
 from thoth.adviser.context import Context

--- a/tests/steps/test_cve.py
+++ b/tests/steps/test_cve.py
@@ -17,7 +17,7 @@
 
 """Test scoring (penalization) based on a CVE."""
 
-import flexmock
+from flexmock import flexmock
 import pytest
 
 from thoth.adviser.enums import RecommendationType

--- a/tests/steps/test_security_indicators.py
+++ b/tests/steps/test_security_indicators.py
@@ -17,7 +17,7 @@
 
 """Test Security Indicator step."""
 
-import flexmock
+from flexmock import flexmock
 import pytest
 
 from thoth.adviser.enums import RecommendationType

--- a/tests/test_dependency_monkey.py
+++ b/tests/test_dependency_monkey.py
@@ -25,7 +25,7 @@ import random
 import sys
 import json
 
-import flexmock
+from flexmock import flexmock
 import amun
 
 from thoth.adviser.enums import DecisionType

--- a/tests/test_dm_report.py
+++ b/tests/test_dm_report.py
@@ -17,7 +17,7 @@
 
 """Test adviser's context passed to pipeline units."""
 
-import flexmock
+from flexmock import flexmock
 
 from .base import AdviserTestCase
 

--- a/tests/test_pipeline_builder.py
+++ b/tests/test_pipeline_builder.py
@@ -21,7 +21,7 @@ import os
 from typing import Union
 from typing import Dict
 
-import flexmock
+from flexmock import flexmock
 import pytest
 from pathlib import Path
 import json

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -17,7 +17,7 @@
 
 """Test pipeline configuration and its manipulation."""
 
-import flexmock
+from flexmock import flexmock
 
 from thoth.adviser.pipeline_config import PipelineConfig
 from thoth.adviser.report import Report

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -18,7 +18,7 @@
 """Test predictor and its core functionality."""
 
 import os
-import flexmock
+from flexmock import flexmock
 import pytest
 
 from .base import AdviserTestCase

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -20,7 +20,7 @@
 
 import os
 import json
-import flexmock
+from flexmock import flexmock
 from itertools import chain
 
 from thoth.adviser.product import Product

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -18,7 +18,7 @@
 """Test resolution of software packages."""
 
 import pytest
-import flexmock
+from flexmock import flexmock
 
 import gc
 import math


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/micropipenv/pull/207
See: https://github.com/flexmock/flexmock/blob/master/CHANGELOG.md#changed

## This introduces a breaking change

- [x] No

## This should yield a new module release

- [x] No
