### PR TITLE
Move recommendation type information more to the top

### DIFF
--- a/tests/boots/test_environment_info.py
+++ b/tests/boots/test_environment_info.py
@@ -71,6 +71,11 @@ class TestEnvironmentInfoBoot(AdviserUnitTestCase):
                 },
                 [
                     {
+                        "link": "https://thoth-station.ninja/recommendation-types/",
+                        "message": "Using recommendation type 'latest'",
+                        "type": "INFO",
+                    },
+                    {
                         "link": jl("env"),
                         "message": "Resolving for runtime environment named 'rhel-9'",
                         "type": "INFO",
@@ -82,11 +87,6 @@ class TestEnvironmentInfoBoot(AdviserUnitTestCase):
                     {
                         "link": jl("env"),
                         "message": "Resolving for Python version '3.6'",
-                        "type": "INFO",
-                    },
-                    {
-                        "link": "https://thoth-station.ninja/recommendation-types/",
-                        "message": "Using recommendation type 'latest'",
                         "type": "INFO",
                     },
                     {
@@ -128,6 +128,11 @@ class TestEnvironmentInfoBoot(AdviserUnitTestCase):
                 {},
                 [
                     {
+                        "link": "https://thoth-station.ninja/recommendation-types/",
+                        "message": "Using recommendation type 'latest'",
+                        "type": "INFO",
+                    },
+                    {
                         "link": jl("env"),
                         "message": "Resolving for runtime environment named 'UNKNOWN'",
                         "type": "INFO",
@@ -139,11 +144,6 @@ class TestEnvironmentInfoBoot(AdviserUnitTestCase):
                     {
                         "link": jl("env"),
                         "message": "Resolving for Python version '3.6'",
-                        "type": "INFO",
-                    },
-                    {
-                        "link": "https://thoth-station.ninja/recommendation-types/",
-                        "message": "Using recommendation type 'latest'",
                         "type": "INFO",
                     },
                     {"link": jl("env"), "message": "Using platform 'UNKNOWN'", "type": "INFO"},

--- a/thoth/adviser/boots/environment_info.py
+++ b/thoth/adviser/boots/environment_info.py
@@ -62,6 +62,11 @@ class EnvironmentInfoBoot(Boot):
         self.context.stack_info.extend(
             [
                 {
+                    "message": f"Using recommendation type {recommendation_type!r}",
+                    "link": "https://thoth-station.ninja/recommendation-types/",
+                    "type": "INFO",
+                },
+                {
                     "message": f"Resolving for runtime environment named " f"{runtime_environment.name or 'UNKNOWN'!r}",
                     "link": self._JUSTIFICATION_LINK_ENV,
                     "type": "INFO",
@@ -75,11 +80,6 @@ class EnvironmentInfoBoot(Boot):
                 {
                     "message": f"Resolving for Python version {self.context.project.python_version!r}",
                     "link": self._JUSTIFICATION_LINK_ENV,
-                    "type": "INFO",
-                },
-                {
-                    "message": f"Using recommendation type {recommendation_type!r}",
-                    "link": "https://thoth-station.ninja/recommendation-types/",
                     "type": "INFO",
                 },
                 {


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

As of now, recommendation type in placed between other environment information that might be not nice from UX point of view:

```
  https://thoth-station.ninja/j/py_version                   │ No version of Python specified explicitly, assigning the one found in Thoth's      │ -            │ ⚠️ WARNING  
                                                             │ configuration: '3.6'                                                               │              │            
  https://thoth-station.ninja/j/env                          │ Resolving for runtime environment named 'my_project'                               │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/env                          │ Resolving for operating system 'rhel' in version '8.0'                             │ -            │ -          
  https://thoth-station.ninja/j/env                          │ Resolving for Python version '3.6'                                                 │ -            │ ✔️ INFO     
  https://thoth-station.ninja/recommendation-types/          │ Using recommendation type 'latest'                                                 │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/env                          │ Using platform 'UNKNOWN'                                                           │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/env                          │ No constraints supplied to the resolution process                                  │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/env                          │ Using supplied static source code analysis                                         │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/env                          │ No containerized environment used                                                  │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/env                          │ Using CPU family 'UNKNWON' model 'UNKNOWN'                                         │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/env                          │ No CUDA used                                                                       │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/env                          │ No cuDNN used                                                                      │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/env                          │ No OpenBLAS used                                                                   │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/env                          │ No OpenMPI used                                                                    │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/env                          │ No MKL used                                                                        │ -            │ ✔️ INFO     
  https://thoth-station.ninja/j/eol_env                      │ Runtime environment used is no longer supported, it is recommended to switch to    │ -            │ ⚠️ WARNING  
                                                             │ another runtime environment                                                        │              │            

```

Let's move the information more up so env information is grouped together.