### PR TITLE
Warn users if they provide too lax version range specifiers

### DIFF
--- a/tests/boots/test_version_check.py
+++ b/tests/boots/test_version_check.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Test version checking boot."""
+
+from thoth.adviser.boots import VersionCheckBoot
+from thoth.adviser.context import Context
+from thoth.adviser.pipeline_builder import PipelineBuilderContext
+from thoth.adviser.enums import RecommendationType
+from thoth.common import get_justification_link as jl
+
+from ..base import AdviserUnitTestCase
+
+
+class TestVersionCheckBoot(AdviserUnitTestCase):
+    """A boot that checks if versions are too lax."""
+
+    UNIT_TESTED = VersionCheckBoot
+
+    def test_verify_multiple_should_include(self) -> None:
+        """Verify multiple should_include calls do not loop endlessly."""
+        builder_context = PipelineBuilderContext(recommendation_type=RecommendationType.LATEST)
+        self.verify_multiple_should_include(builder_context)
+
+    def test_no_version(self, context: Context) -> None:
+        """Test providing stack information if there is no version identifier."""
+        context.project.pipfile.packages.packages.clear()
+        context.project.pipfile.dev_packages.packages.clear()
+
+        context.project.add_package("flask")
+        assert not context.stack_info
+
+        boot = self.UNIT_TESTED()
+        with boot.assigned_context(context):
+            boot.run()
+
+        assert context.stack_info == [
+            {
+                "link": jl("lax_version"),
+                "message": "No version range specifier for 'flask' found, it is recommended to "
+                "specify version ranges in requirements",
+                "type": "WARNING",
+            },
+        ]
+
+    def test_lax_version(self, context: Context) -> None:
+        """Test providing stack information if the used version is too lax."""
+        context.project.pipfile.packages.packages.clear()
+        context.project.pipfile.dev_packages.packages.clear()
+
+        context.project.add_package("flask", ">=0.12")
+        assert not context.stack_info
+
+        boot = self.UNIT_TESTED()
+        with boot.assigned_context(context):
+            boot.run()
+
+        assert context.stack_info == [
+            {
+                "link": jl("lax_version"),
+                "message": "Version range specifier ('>=0.12') for 'flask' might be too lax",
+                "type": "WARNING",
+            },
+        ]
+
+    def test_version_ok(self, context: Context) -> None:
+        """Test not providing stack information if the used version is okay."""
+        context.project.pipfile.packages.packages.clear()
+        context.project.pipfile.dev_packages.packages.clear()
+
+        context.project.add_package("flask", ">=0.12,<2.0.0")
+        assert not context.stack_info
+
+        boot = self.UNIT_TESTED()
+        with boot.assigned_context(context):
+            boot.run()
+
+        assert context.stack_info == []

--- a/thoth/adviser/boots/__init__.py
+++ b/thoth/adviser/boots/__init__.py
@@ -33,6 +33,7 @@ from .thoth_s2i import ThothS2IBoot
 from .thoth_s2i_info import ThothS2IInfoBoot
 from .thoth_search import ThothSearchBoot
 from .ubi import UbiBoot
+from .version_check import VersionCheckBoot
 
 # from ._debug import MemTraceBoot
 
@@ -47,6 +48,7 @@ __all__ = [
     "CveTimestampBoot",
     "LabelsBoot",
     "PipfileHashBoot",  # Should be placed before any changes to the input.
+    "VersionCheckBoot",
     "GPUBoot",  # Should be placed before any GPU specific pipeline unit.
     "ThothS2IBoot",
     "ThothS2IInfoBoot",

--- a/thoth/adviser/boots/version_check.py
+++ b/thoth/adviser/boots/version_check.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# thoth-adviser
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""A boot to check for fully specified environment."""
+
+import logging
+from typing import Any
+from typing import Dict
+from typing import Generator
+from typing import TYPE_CHECKING
+from itertools import chain
+from packaging.version import Version
+from packaging.specifiers import SpecifierSet
+
+import attr
+from thoth.common import get_justification_link as jl
+
+from ..boot import Boot
+
+if TYPE_CHECKING:
+    from ..pipeline_builder import PipelineBuilderContext
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@attr.s(slots=True)
+class VersionCheckBoot(Boot):
+    """A boot that checks if versions are too lax."""
+
+    _JUSTIFICATION_VERSION_TOO_LAX = jl("lax_version")
+
+    # Some arbitrary large version to detect possibly version specifiers without any upper limit.
+    _LARGE_VERSION = Version("9999999999")
+
+    @classmethod
+    def should_include(cls, builder_context: "PipelineBuilderContext") -> Generator[Dict[str, Any], None, None]:
+        """Register self, always."""
+        if builder_context.is_adviser_pipeline() and not builder_context.is_included(cls):
+            yield {}
+            return None
+
+        yield from ()
+        return None
+
+    def run(self) -> None:
+        """Check if versions are not too lax."""
+        for package_version in chain(
+            self.context.project.pipfile.packages.packages.values(),
+            self.context.project.pipfile.dev_packages.packages.values(),
+        ):
+            if not package_version.version or package_version.version == "*":
+                self.context.stack_info.append(
+                    {
+                        "type": "WARNING",
+                        "message": f"No version range specifier for {package_version.name!r} found, it is "
+                        f"recommended to specify version ranges in requirements",
+                        "link": self._JUSTIFICATION_VERSION_TOO_LAX,
+                    }
+                )
+            elif self._LARGE_VERSION in SpecifierSet(package_version.version):
+                self.context.stack_info.append(
+                    {
+                        "type": "WARNING",
+                        "message": f"Version range specifier ({package_version.version!r}) for "
+                        f"{package_version.name!r} might be too lax",
+                        "link": self._JUSTIFICATION_VERSION_TOO_LAX,
+                    }
+                )


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
