### PR TITLE
Propagate information about package name when not solved

### DIFF
--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -684,6 +684,7 @@ class Resolver:
                         "message": error_msg,
                         "type": "ERROR",
                         "link": jl("solve_direct"),
+                        "package_name": package_version.name,
                     }
                 )
                 _LOGGER.warning("%s - see %s", error_msg, jl("solve_direct"))


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description
```
  Link                                              │ Message                                                                                                                  │ Package name           │ Type       
 ═══════════════════════════════════════════════════╪══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╪════════════════════════╪═══════════ 
  https://thoth-station.ninja/j/solve_direct        │ No versions were found for direct dependency 'foo-someunknownpackage'; operating system 'rhel' in OS version '8' for     │ -                      │ ❌ ERROR   
                                                    │ Python in version '3.8' using platform 'linux-x86_64'                                                                    │                        │            
```