### PR TITLE
Place EOL warning boot after RHELVersionBoot

### DIFF
--- a/thoth/adviser/boots/__init__.py
+++ b/thoth/adviser/boots/__init__.py
@@ -56,8 +56,8 @@ __all__ = [
     "PythonVersionBoot",
     "EnvironmentInfoBoot",
     "SolvedSoftwareEnvironmentBoot",
-    "SolversConfiguredBoot",  # Should be placed after SolvedSoftwareEnvironmentBoot.
     "RHELVersionBoot",
+    "SolversConfiguredBoot",  # Should be placed after SolvedSoftwareEnvironmentBoot and RHELVersionBoot
     "PrescriptionReleaseBoot",
     "FullySpecifiedEnvironment",
     "SolvedSoftwareEnvironmentBoot",


### PR DESCRIPTION
## Related Issues and Dependencies

Adviser reports environments as EOL if users supply a minor version of UBI/RHEL releases. This change makes sure EOL is not reported in cases when minor versions are used as they are adjusted by `RHELVersionBoot`:

```
  https://thoth-station.ninja/j/eol_env             │ Runtime environment used is no longer supported, it is recommended to switch to another     │ ⚠️ WARNING  
                                                    │ runtime environment                                                                         │            
```

## This introduces a breaking change

- [x] No
