### PR TITLE
Add missing message type to environment info

### DIFF
--- a/tests/boots/test_environment_info.py
+++ b/tests/boots/test_environment_info.py
@@ -83,6 +83,7 @@ class TestEnvironmentInfoBoot(AdviserUnitTestCase):
                     {
                         "link": jl("env"),
                         "message": "Resolving for operating system 'rhel' in version '9'",
+                        "type": "INFO",
                     },
                     {
                         "link": jl("env"),
@@ -140,6 +141,7 @@ class TestEnvironmentInfoBoot(AdviserUnitTestCase):
                     {
                         "link": jl("env"),
                         "message": "Resolving for operating system None in version None",
+                        "type": "INFO",
                     },
                     {
                         "link": jl("env"),

--- a/thoth/adviser/boots/environment_info.py
+++ b/thoth/adviser/boots/environment_info.py
@@ -76,6 +76,7 @@ class EnvironmentInfoBoot(Boot):
                     f"{runtime_environment.operating_system.name!r} "
                     f"in version {runtime_environment.operating_system.version!r}",
                     "link": self._JUSTIFICATION_LINK_ENV,
+                    "type": "INFO",
                 },
                 {
                     "message": f"Resolving for Python version {self.context.project.python_version!r}",


### PR DESCRIPTION
## Related Issues and Dependencies

```
  https://thoth-station.ninja/j/env                                      │ Resolving for runtime environment named 'ubi8'                         │ ✔️ INFO     
  https://thoth-station.ninja/j/env                                      │ Resolving for operating system 'rhel' in version '8'                   │ -          
  https://thoth-station.ninja/j/env                                      │ Resolving for Python version '3.6'                                     │ ✔️ INFO     
```

## This introduces a breaking change

- [x] No
