### PR TITLE
Get environments from solvers configmap and fix tests for solved software environments

### DIFF
--- a/tests/boots/test_solved_software_environment.py
+++ b/tests/boots/test_solved_software_environment.py
@@ -61,13 +61,17 @@ class TestSolvedSoftwareEnvironmentBoot(AdviserUnitTestCase):
         context.project.runtime_environment.operating_system.name = "fedora"
         context.project.runtime_environment.operating_system.version = "32"
         context.project.runtime_environment.python_version = "3.8"
-        assert {
+        context.graph.should_receive("solved_software_environment_exists").with_args(
+            os_name="fedora", os_version="32", python_version="3.8"
+        ).and_return(True).once()
+
+        assert [{
             "message": f"Consider using {context.project.runtime_environment.operating_system.name} "
             f"in version {context.project.runtime_environment.operating_system.version} "
             f"with Python {context.project.runtime_environment.python_version}",
             "type": "ERROR",
             "link": jl("solved_sw_env"),
-        } in context.stack_info
+        }] == context.stack_info
 
         unit = SolvedSoftwareEnvironmentBoot()
         with unit.assigned_context(context):
@@ -78,13 +82,25 @@ class TestSolvedSoftwareEnvironmentBoot(AdviserUnitTestCase):
         context.project.runtime_environment.operating_system.name = "fedora"
         context.project.runtime_environment.operating_system.version = "32"
         context.project.runtime_environment.python_version = "3.8"
-        assert {
+        context.graph.should_receive("solved_software_environment_exists").with_args(
+            os_name="fedora", os_version="32", python_version="3.8"
+        ).and_return(False).once()
+        context.graph.should_receive(
+            "get_solved_python_package_versions_software_environment_all"
+        ).with_args().and_return(
+            [
+                {"os_name": "rhel", "os_version": "9.0", "python_version": "3.8"},
+                {"os_name": "fedora", "os_version": "31", "python_version": "3.7"},
+            ]
+        ).once()
+
+        assert [{
             "message": f"Consider using {context.project.runtime_environment.operating_system.name} "
             f"in version {context.project.runtime_environment.operating_system.version} "
             f"with Python {context.project.runtime_environment.python_version}",
             "type": "ERROR",
             "link": jl("solved_sw_env"),
-        } not in context.stack_info
+        }] != context.stack_info
 
         unit = SolvedSoftwareEnvironmentBoot()
         with pytest.raises(NotAcceptable):

--- a/tests/boots/test_solved_software_environment.py
+++ b/tests/boots/test_solved_software_environment.py
@@ -33,6 +33,7 @@ class TestSolvedSoftwareEnvironmentBoot(AdviserUnitTestCase):
     """Test solved software environment boot."""
 
     UNIT_TESTED = SolvedSoftwareEnvironmentBoot
+    SolvedSoftwareEnvironmentBoot._THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS = "solver-fedora-32-py38"
 
     def test_verify_multiple_should_include(self, builder_context: PipelineBuilderContext) -> None:
         """Verify multiple should_include calls do not loop endlessly."""
@@ -65,14 +66,6 @@ class TestSolvedSoftwareEnvironmentBoot(AdviserUnitTestCase):
             os_name="fedora", os_version="32", python_version="3.8"
         ).and_return(True).once()
 
-        assert [{
-            "message": f"Consider using {context.project.runtime_environment.operating_system.name} "
-            f"in version {context.project.runtime_environment.operating_system.version} "
-            f"with Python {context.project.runtime_environment.python_version}",
-            "type": "ERROR",
-            "link": jl("solved_sw_env"),
-        }] == context.stack_info
-
         unit = SolvedSoftwareEnvironmentBoot()
         with unit.assigned_context(context):
             assert unit.run() is None
@@ -85,22 +78,16 @@ class TestSolvedSoftwareEnvironmentBoot(AdviserUnitTestCase):
         context.graph.should_receive("solved_software_environment_exists").with_args(
             os_name="fedora", os_version="32", python_version="3.8"
         ).and_return(False).once()
-        context.graph.should_receive(
-            "get_solved_python_package_versions_software_environment_all"
-        ).with_args().and_return(
-            [
-                {"os_name": "rhel", "os_version": "9.0", "python_version": "3.8"},
-                {"os_name": "fedora", "os_version": "31", "python_version": "3.7"},
-            ]
-        ).once()
 
-        assert [{
-            "message": f"Consider using {context.project.runtime_environment.operating_system.name} "
-            f"in version {context.project.runtime_environment.operating_system.version} "
-            f"with Python {context.project.runtime_environment.python_version}",
-            "type": "ERROR",
-            "link": jl("solved_sw_env"),
-        }] != context.stack_info
+        assert [
+            {
+                "message": f"Consider using {context.project.runtime_environment.operating_system.name} "
+                f"in version {context.project.runtime_environment.operating_system.version} "
+                f"with Python {context.project.runtime_environment.python_version}",
+                "type": "ERROR",
+                "link": jl("solved_sw_env"),
+            }
+        ] != context.stack_info
 
         unit = SolvedSoftwareEnvironmentBoot()
         with pytest.raises(NotAcceptable):

--- a/tests/boots/test_solved_software_environment.py
+++ b/tests/boots/test_solved_software_environment.py
@@ -26,6 +26,8 @@ from thoth.adviser.exceptions import NotAcceptable
 from thoth.adviser.pipeline_builder import PipelineBuilderContext
 from ..base import AdviserUnitTestCase
 
+from thoth.common import get_justification_link as jl
+
 
 class TestSolvedSoftwareEnvironmentBoot(AdviserUnitTestCase):
     """Test solved software environment boot."""
@@ -59,9 +61,13 @@ class TestSolvedSoftwareEnvironmentBoot(AdviserUnitTestCase):
         context.project.runtime_environment.operating_system.name = "fedora"
         context.project.runtime_environment.operating_system.version = "32"
         context.project.runtime_environment.python_version = "3.8"
-        context.graph.should_receive("solved_software_environment_exists").with_args(
-            os_name="fedora", os_version="32", python_version="3.8"
-        ).and_return(True).once()
+        assert {
+            "message": f"Consider using {context.project.runtime_environment.operating_system.name} "
+            f"in version {context.project.runtime_environment.operating_system.version} "
+            f"with Python {context.project.runtime_environment.python_version}",
+            "type": "ERROR",
+            "link": jl("solved_sw_env"),
+        } in context.stack_info
 
         unit = SolvedSoftwareEnvironmentBoot()
         with unit.assigned_context(context):
@@ -72,17 +78,13 @@ class TestSolvedSoftwareEnvironmentBoot(AdviserUnitTestCase):
         context.project.runtime_environment.operating_system.name = "fedora"
         context.project.runtime_environment.operating_system.version = "32"
         context.project.runtime_environment.python_version = "3.8"
-        context.graph.should_receive("solved_software_environment_exists").with_args(
-            os_name="fedora", os_version="32", python_version="3.8"
-        ).and_return(False).once()
-        context.graph.should_receive(
-            "get_solved_python_package_versions_software_environment_all"
-        ).with_args().and_return(
-            [
-                {"os_name": "rhel", "os_version": "9.0", "python_version": "3.8"},
-                {"os_name": "fedora", "os_version": "31", "python_version": "3.7"},
-            ]
-        ).once()
+        assert {
+            "message": f"Consider using {context.project.runtime_environment.operating_system.name} "
+            f"in version {context.project.runtime_environment.operating_system.version} "
+            f"with Python {context.project.runtime_environment.python_version}",
+            "type": "ERROR",
+            "link": jl("solved_sw_env"),
+        } not in context.stack_info
 
         unit = SolvedSoftwareEnvironmentBoot()
         with pytest.raises(NotAcceptable):

--- a/thoth/adviser/boots/solved_software_environment.py
+++ b/thoth/adviser/boots/solved_software_environment.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
     from ..pipeline_builder import PipelineBuilderContext
 
 _LOGGER = logging.getLogger(__name__)
-_THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS = os.getenv("THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS", "")
 
 
 @attr.s(slots=True)
@@ -43,6 +42,7 @@ class SolvedSoftwareEnvironmentBoot(Boot):
     """A boot to check for solved software environment before running any resolution."""
 
     _JUSTIFICATION_LINK = jl("solved_sw_env")
+    _THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS = os.getenv("THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS", "")
 
     @classmethod
     def should_include(cls, builder_context: "PipelineBuilderContext") -> Generator[Dict[str, Any], None, None]:
@@ -81,7 +81,7 @@ class SolvedSoftwareEnvironmentBoot(Boot):
         _LOGGER.warning("%s - %s", msg, self._JUSTIFICATION_LINK)
         _LOGGER.warning("Available configurations:")
 
-        solvers = _THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS.split(" ")
+        solvers = self._THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS.split(" ")
         configurations = []
         for solver in solvers:
             item = OpenShift.parse_python_solver_name(solver.strip())

--- a/thoth/adviser/boots/solved_software_environment.py
+++ b/thoth/adviser/boots/solved_software_environment.py
@@ -81,7 +81,7 @@ class SolvedSoftwareEnvironmentBoot(Boot):
         _LOGGER.warning("%s - %s", msg, self._JUSTIFICATION_LINK)
         _LOGGER.warning("Available configurations:")
 
-        solvers = self._THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS.split(" ")
+        solvers = self._THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS.split()
         configurations = []
         for solver in solvers:
             item = OpenShift.parse_python_solver_name(solver.strip())

--- a/thoth/adviser/boots/solved_software_environment.py
+++ b/thoth/adviser/boots/solved_software_environment.py
@@ -18,6 +18,7 @@
 """A boot to check for solved software environment before running any resolution."""
 
 import logging
+import os
 from typing import Generator
 from typing import Dict
 from typing import Any
@@ -25,6 +26,7 @@ from typing import TYPE_CHECKING
 
 import attr
 from thoth.common import get_justification_link as jl
+from thoth.common import OpenShift
 
 from ..boot import Boot
 from ..exceptions import NotAcceptable
@@ -33,6 +35,7 @@ if TYPE_CHECKING:
     from ..pipeline_builder import PipelineBuilderContext
 
 _LOGGER = logging.getLogger(__name__)
+_THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS = os.getenv("THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS", "")
 
 
 @attr.s(slots=True)
@@ -78,7 +81,18 @@ class SolvedSoftwareEnvironmentBoot(Boot):
         _LOGGER.warning("%s - %s", msg, self._JUSTIFICATION_LINK)
         _LOGGER.warning("Available configurations:")
 
-        configurations = self.context.graph.get_solved_python_package_versions_software_environment_all()
+        solvers = _THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS.split(" ")
+        configurations = []
+        for solver in solvers:
+            item = OpenShift.parse_python_solver_name(solver.strip())
+            configurations.append(item)
+
+            if item["os_name"] == "rhel":
+                # Duplicate entry as we can also guide on the same UBI environment. UBI and RHEL are binary compatible.
+                other_item = dict(item)
+                other_item["os_name"] = "ubi"
+                configurations.append(other_item)
+
         _LOGGER.warning("{:<16} {:<16} {:<8}".format("OS name", "OS version", "Python version"))
         for conf in sorted(
             configurations,


### PR DESCRIPTION
## Related Issues and Dependencies

Related to #2245 

## This introduces a breaking change

- [x] No

## This Pull Request implements

Get environments from solvers configmap instead of the database and adjust tests to match the suggested implementation
