### PR TITLE
Obtian the very first secure software stack

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -13,7 +13,7 @@ case $THOTH_ADVISER_SUBCOMMAND in
         ;;
     'advise')
         # No need to compute all the stacks, the first one found is sufficient to return.
-        [ "${THOTH_ADVISER_RECOMMENDATION_TYPE}" = "latest" ] && export THOTH_ADVISER_LIMIT=1
+        [ "${THOTH_ADVISER_RECOMMENDATION_TYPE}" = "latest" -o "${THOTH_ADVISER_RECOMMENDATION_TYPE}" = "security" ] && export THOTH_ADVISER_LIMIT=1
         exec /opt/app-root/bin/python3 thoth-adviser advise
         ;;
     *)


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

It might be not needed to score more than one software stack when the recommendation type is set to security. The very first secure software stack found can be returned.
