### PR TITLE
Change link to Thoth Search for a package

### DIFF
--- a/thoth/adviser/wraps/thoth_search_package.py
+++ b/thoth/adviser/wraps/thoth_search_package.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 _THOTH_SEARCH_PACKAGE_URL = os.getenv(
     "THOTH_SEARCH_PACKAGE_URL",
-    "https://thoth-station.ninja/thoth-search/package/{package_name}/"
+    "https://thoth-station.ninja/search/package/{package_name}/"
     "{package_version}/{index_url}/{os_name}/{os_version}/{python_version}",
 )
 


### PR DESCRIPTION
## Related Issues and Dependencies

We have moved from `thoth-search` to just `search`.