### PR TITLE
update AICoE-CI image version

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -3,7 +3,7 @@ check:
 release:
   - upload-pypi-sesheta
 build:
-  base-image: quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.26.0
+  base-image: quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.3
   build-stratergy: Source
   registry: quay.io
   registry-org: thoth-station


### PR DESCRIPTION
merging this needs a patch version bump of adviser.

This update is mainly driven by the big bunch of security issues with https://quay.io/repository/thoth-station/adviser/manifest/sha256:7633310ac8ea5e1028a9f4d02459ecfbe6055cf585158fffab9a0452599be3d2?tab=vulnerabilities

Signed-off-by: Christoph Görn <goern@redhat.com>
