### PR TITLE
Fix the URL path when pointing to the search Web UI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,41 +2,36 @@
 ---
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.13
+    rev: v1.2.0
     hooks:
       - id: remove-tabs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
-      - id: trailing-whitespace
-      - id: check-merge-conflict
-      - id: end-of-file-fixer
       - id: check-added-large-files
+      - id: check-ast
       - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-json
+      - id: check-merge-conflict
       - id: check-symlinks
-      - id: detect-private-key
-      - id: check-ast
+      - id: check-toml
+      - id: check-yaml
       - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
 
   - repo: https://github.com/pycqa/pydocstyle.git
     rev: 6.1.1
     hooks:
       - id: pydocstyle
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
-    hooks:
-      - id: check-toml
-      - id: check-yaml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.950
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,7 +6,7 @@ presubmits:
     context: aicoe-ci/prow/pre-commit
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-precommit-py38:v0.13.0
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.14.3
           command:
             - "pre-commit"
             - "run"
@@ -26,7 +26,7 @@ presubmits:
     context: aicoe-ci/prow/pytest
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-pytest-py38:v0.13.0
+        - image: quay.io/thoth-station/thoth-pytest-py38:v0.14.3
           command:
              - "run-pytest"
           resources:

--- a/tests/prescription/v1/test_add_package_step.py
+++ b/tests/prescription/v1/test_add_package_step.py
@@ -216,7 +216,7 @@ run:
 
     def test_run_package_version_not_solved(self, context: Context, state: State) -> None:
         """Test running the prescription based on the dependency not solved."""
-        prescription_str = f"""
+        prescription_str = """
 name: AddPackageStep
 type: step.AddPackage
 should_include:
@@ -313,7 +313,7 @@ run:
 
     def test_run_package_version_index_url_not_enabled(self, context: Context, state: State) -> None:
         """Test running the prescription based on the dependency introduced when index_url is not enabled."""
-        prescription_str = f"""
+        prescription_str = """
 name: AddPackageStep
 type: step.AddPackage
 should_include:
@@ -413,7 +413,7 @@ run:
 
     def test_run_package_version_index_url_not_known(self, context: Context, state: State) -> None:
         """Test running the prescription based on the dependency introduced when index_url is not known."""
-        prescription_str = f"""
+        prescription_str = """
 name: AddPackageStep
 type: step.AddPackage
 should_include:
@@ -513,7 +513,7 @@ run:
 
     def test_run_package_version_already_resolved(self, context: Context, state: State) -> None:
         """Test running the prescription when the given package is already in the resolved state."""
-        prescription_str = f"""
+        prescription_str = """
 name: AddPackageStep
 type: step.AddPackage
 should_include:
@@ -614,7 +614,7 @@ run:
 
     def test_run_package_version_already_resolved_same_name(self, context: Context, state: State) -> None:
         """Test running the prescription when the given package is already in the resolved state (same name)."""
-        prescription_str = f"""
+        prescription_str = """
 name: AddPackageStep
 type: step.AddPackage
 should_include:
@@ -716,7 +716,7 @@ run:
 
     def test_run_package_version_add_package_multi(self, context: Context, state: State) -> None:
         """Test running the unit multiple times with stack info and justification reported once."""
-        prescription_str = f"""
+        prescription_str = """
 name: AddPackageStep
 type: step.AddPackage
 should_include:

--- a/tests/prescription/v1/test_gh_release_notes.py
+++ b/tests/prescription/v1/test_gh_release_notes.py
@@ -308,7 +308,7 @@ run:
 
     def test_instantiate_multiple(self) -> None:
         """Test instantiating multiple GitHub release notes wraps from a single prescription."""
-        prescription_str = f"""
+        prescription_str = """
 name: GHReleaseNotes
 type: wrap.GHReleaseNotes
 should_include:

--- a/tests/prescription/v1/test_group.py
+++ b/tests/prescription/v1/test_group.py
@@ -34,7 +34,7 @@ class TestGroupStepPrescription(AdviserUnitPrescriptionTestCase):
 
     def test_should_include(self, builder_context: PipelineBuilderContext) -> None:
         """Test calculating configuration for the given prescription unit."""
-        prescription_str = f"""\
+        prescription_str = """\
 name: GroupStep
 type: step.Group
 should_include:
@@ -182,7 +182,7 @@ run:
 
     def test_should_include_groups(self, builder_context: PipelineBuilderContext) -> None:
         """Test calculating configuration for the given prescription unit, multiple groups."""
-        prescription_str = f"""\
+        prescription_str = """\
 name: GroupStep
 type: step.Group
 should_include:

--- a/tests/sieves/test_experimental_conf_index.py
+++ b/tests/sieves/test_experimental_conf_index.py
@@ -147,7 +147,7 @@ tensorflow = "*"
         """Test NOT removing dependencies based on index configured."""
         pv = PackageVersion(
             name="tensorflow",
-            version=f"==2.4.1",
+            version="==2.4.1",
             index=Source("https://pypi.org/simple"),
             develop=False,
         )
@@ -165,7 +165,7 @@ tensorflow = "*"
         """Test removing dependencies based on index configured."""
         pv = PackageVersion(
             name="tensorflow",
-            version=f"==2.4.1",
+            version="==2.4.1",
             index=Source("https://pypi.org/simple"),
             develop=False,
         )

--- a/thoth/adviser/boots/environment_info.py
+++ b/thoth/adviser/boots/environment_info.py
@@ -89,14 +89,14 @@ class EnvironmentInfoBoot(Boot):
                     "type": "INFO",
                 },
                 {
-                    "message": f"Using constraints provided"
+                    "message": "Using constraints provided"
                     if self.context.project.constraints.package_versions
                     else "No constraints supplied to the resolution process",
                     "link": self._JUSTIFICATION_LINK_ENV,
                     "type": "INFO",
                 },
                 {
-                    "message": f"Using supplied static source code analysis"
+                    "message": "Using supplied static source code analysis"
                     if self.context.library_usage
                     else "No static source code analysis supplied",
                     "link": self._JUSTIFICATION_LINK_ENV,

--- a/thoth/adviser/boots/thoth_search.py
+++ b/thoth/adviser/boots/thoth_search.py
@@ -59,7 +59,7 @@ class ThothSearchBoot(Boot):
         self.context.stack_info.append(
             {
                 "type": "INFO",
-                "message": f"Results can be browsed in Thoth search",
+                "message": "Results can be browsed in Thoth search",
                 "link": self._search_url.format(document_id=self._document_id),
             }
         )

--- a/thoth/adviser/boots/thoth_search.py
+++ b/thoth/adviser/boots/thoth_search.py
@@ -33,7 +33,9 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-_THOTH_SEARCH_URL = os.getenv("THOTH_SEARCH_ADVISER_URL", "https://thoth-station.ninja/search/{document_id}/summary")
+_THOTH_SEARCH_URL = os.getenv(
+    "THOTH_SEARCH_ADVISER_URL", "https://thoth-station.ninja/search/advise/{document_id}/summary"
+)
 _DOCUMENT_ID = os.getenv("THOTH_DOCUMENT_ID", "UNKNOWN")
 
 

--- a/thoth/adviser/predictor.py
+++ b/thoth/adviser/predictor.py
@@ -51,7 +51,7 @@ class Predictor:
     @classmethod
     def obtain_default_configuration(cls, config_option_name: str) -> Any:
         """Get the default value assigned to the given configuration option of a predictor instance."""
-        return getattr(cls.__attrs_attrs__, config_option_name).default  # type: ignore
+        return getattr(cls.__attrs_attrs__, config_option_name).default
 
     @classmethod
     @contextmanager

--- a/thoth/adviser/predictors/annealing.py
+++ b/thoth/adviser/predictors/annealing.py
@@ -55,7 +55,7 @@ class AdaptiveSimulatedAnnealing(Predictor):
     def _temperature_function(self, t0: float, context: Context) -> float:
         """Temperature function used to compute new temperature."""
         k = (context.accepted_final_states_count + math.log(context.iteration + 1)) / context.limit
-        temperature = t0 * self.temperature_coefficient ** k
+        temperature = t0 * self.temperature_coefficient**k
         _LOGGER.debug(
             "New temperature for (iteration=%d, t0=%g, accepted final states=%d, limit=%d, beam size= %d, k=%f) = %g",
             context.iteration,

--- a/thoth/adviser/predictors/mcts.py
+++ b/thoth/adviser/predictors/mcts.py
@@ -51,7 +51,7 @@ class MCTS(TemporalDifference):
         # This function, in comparision to TD/SA, does not need to take into account iteration as it
         # works on accepted states.
         k = context.accepted_final_states_count / context.limit
-        temperature = t0 * 0.99 ** k
+        temperature = t0 * 0.99**k
         _LOGGER.debug(
             "New temperature for (iteration=%d, t0=%g, accepted final states=%d, limit=%d, beam size= %d, k=%f) = %g",
             context.iteration,

--- a/thoth/adviser/prescription/v1/unit.py
+++ b/thoth/adviser/prescription/v1/unit.py
@@ -596,7 +596,7 @@ class UnitPrescription(Unit, metaclass=abc.ABCMeta):
             if not symbols_present:
                 if builder_context.iteration == 0:
                     _LOGGER.warning(
-                        f"%s: No symbols found for runtime environment %r", unit_name, runtime_used.base_image
+                        "%s: No symbols found for runtime environment %r", unit_name, runtime_used.base_image
                     )
                 return False
 

--- a/thoth/adviser/resolver.py
+++ b/thoth/adviser/resolver.py
@@ -1369,8 +1369,8 @@ class Resolver:
 
             if len(states) == 0:
                 msg = (
-                    f"Resolver did not find any stack that would satisfy requirements and stack "
-                    f"characteristics given the time allocated"
+                    "Resolver did not find any stack that would satisfy requirements and stack "
+                    "characteristics given the time allocated"
                 )
                 link = jl("no_stack")
                 self.context.stack_info.append(


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->

Fixes: https://github.com/thoth-station/support/issues/219

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- Yes (if a patch release is desired, although this is a minor bugfix)

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->

## This Pull Request implements
<!-- Provide a summary of your changes here. -->

Fix the URL that points to the Thoth Search web UI.

### Description
<!--- Describe your changes in detail here. -->

The correct path is `/search/advise/:id:`, e.g. https://thoth-station.ninja/search/advise/adviser-220520135456-693dce14c5adfe00/summary

Also, this PR includes an update to the pre-commit configuration, and related changes that pre-commit reported during a local run.