### PR TITLE
Implement allowing certain CVEs being present in the application stack

### DIFF
--- a/tests/boots/test_labels.py
+++ b/tests/boots/test_labels.py
@@ -52,7 +52,7 @@ class TestLabelsBoot(AdviserUnitTestCase):
 
     def test_run(self, context: Context) -> None:
         """Test if the given software environment is solved."""
-        context.labels = {"foo": "bar", "baz": "qux"}
+        context.labels = {"foo": "bar", "baz": "qux", "allow-cve": "pysec-2014-10,PYSEC-2014-22"}
 
         assert not context.stack_info
 
@@ -63,4 +63,14 @@ class TestLabelsBoot(AdviserUnitTestCase):
         assert context.stack_info == [
             {"link": jl("labels"), "message": "Considering label foo=bar in the resolution process", "type": "INFO"},
             {"link": jl("labels"), "message": "Considering label baz=qux in the resolution process", "type": "INFO"},
+            {
+                "link": jl("allow_cve"),
+                "message": "Allowing CVE 'PYSEC-2014-10' to be present in the application",
+                "type": "WARNING",
+            },
+            {
+                "link": jl("allow_cve"),
+                "message": "Allowing CVE 'PYSEC-2014-22' to be present in the application",
+                "type": "WARNING",
+            },
         ]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -110,3 +110,15 @@ class TestUnit(AdviserTestCase):
     def test_get_aicoe_configuration(self, package_version, expected) -> None:
         """Check parsing of AICoE specific configuration encoded in the URL."""
         assert Unit.get_aicoe_configuration(package_version) == expected
+
+    def test_construct_allow_cves(self) -> None:
+        """Test constructing allowed CVEs in the application."""
+        allow_cves = {"foo", "bar"}
+
+        Unit._construct_allow_cves(allow_cves, {})
+        assert allow_cves == set()
+
+        allow_cves = {"foo", "bar"}
+
+        Unit._construct_allow_cves(allow_cves, {"key": "value", "allow-cve": "pysec-2014-10,PYSEC-2014-22"})
+        assert allow_cves == {"PYSEC-2014-10", "PYSEC-2014-22"}

--- a/thoth/adviser/boots/labels.py
+++ b/thoth/adviser/boots/labels.py
@@ -38,7 +38,8 @@ _LOGGER = logging.getLogger(__name__)
 class LabelsBoot(Boot):
     """A boot to notify about labels used during the resolution."""
 
-    _JUSTIFICATION_LINK = jl("labels")
+    _JUSTIFICATION_LINK_LABELS = jl("labels")
+    _JUSTIFICATION_LINK_ALLOW_CVE = jl("allow_cve")
 
     @classmethod
     def should_include(cls, builder_context: "PipelineBuilderContext") -> Generator[Dict[str, Any], None, None]:
@@ -53,12 +54,24 @@ class LabelsBoot(Boot):
     def run(self) -> None:
         """Notify about labels used during the resolution process.."""
         for key, value in self.context.labels.items():
-            msg = f"Considering label {key}={value} in the resolution process"
-            _LOGGER.info("%s - see %s", msg, self._JUSTIFICATION_LINK)
-            self.context.stack_info.append(
-                {
-                    "message": msg,
-                    "type": "INFO",
-                    "link": self._JUSTIFICATION_LINK,
-                }
-            )
+            if key != "allow-cve":
+                msg = f"Considering label {key}={value} in the resolution process"
+                _LOGGER.info("%s - see %s", msg, self._JUSTIFICATION_LINK_LABELS)
+                self.context.stack_info.append(
+                    {
+                        "message": msg,
+                        "type": "INFO",
+                        "link": self._JUSTIFICATION_LINK_LABELS,
+                    }
+                )
+            else:
+                for allow_cve in value.split(","):
+                    msg = f"Allowing CVE {allow_cve.upper()!r} to be present in the application"
+                    _LOGGER.warning("%s - see %s", msg, self._JUSTIFICATION_LINK_ALLOW_CVE)
+                    self.context.stack_info.append(
+                        {
+                            "message": msg,
+                            "type": "WARNING",
+                            "link": self._JUSTIFICATION_LINK_ALLOW_CVE,
+                        }
+                    )

--- a/thoth/adviser/unit.py
+++ b/thoth/adviser/unit.py
@@ -24,7 +24,9 @@ import re
 from typing import Any
 from typing import Dict
 from typing import Generator
+from typing import List
 from typing import Optional
+from typing import Set
 from typing import Tuple
 from typing import Union
 from contextlib import contextmanager
@@ -33,6 +35,7 @@ import attr
 from voluptuous import Schema
 from voluptuous import Required
 from voluptuous import Any as SchemaAny
+from thoth.common import get_justification_link as jl
 from thoth.python import PackageVersion
 
 from .context import Context
@@ -236,6 +239,18 @@ class Unit(metaclass=abc.ABCMeta):
             thoth_s2i_image_version = thoth_s2i_image_version[1:]
 
         return thoth_s2i_image_name, thoth_s2i_image_version
+
+    @staticmethod
+    def _construct_allow_cves(allow_cves: Set[str], labels: Dict[str, str]) -> None:
+        """Check what CVEs should be skipped based on labels supplied to the resolution process."""
+        allow_cves.clear()
+        allow_cve_label = labels.get("allow-cve")
+        if not allow_cve_label:
+            return
+
+        for item in allow_cve_label.split(","):
+            cve_id = item.upper()
+            allow_cves.add(cve_id)
 
     def pre_run(self) -> None:  # noqa: D401
         """Called before running any pipeline unit with context already assigned.


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/adviser/issues/2342

## This introduces a breaking change

- No

### Description

Allow users to specify `allow-cve` label in their `.thoth.yaml` configuration file or by supplying `--labels` option to Thamos CLI. This feature allows specifying which CVEs are acceptable in the application stack. Example:

```yaml
labels:
  allow-cve: PYSEC-2021-94,PYSEC-2021-2
```
