### PR TITLE
Remove the maintainers section from .thoth.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: remove-tabs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -31,7 +31,7 @@ repos:
       - id: pydocstyle
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.961
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'
@@ -39,7 +39,7 @@ repos:
         additional_dependencies: [attrs~=19.3]
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
 

--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -18,11 +18,6 @@ managers:
   - name: info
   - name: version
     configuration:
-      maintainers:
-        - goern
-        - fridex
-        - harshad16
-        - mayaCostantini
       assignees:
         - sesheta
       labels: [bot]

--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,13 @@
 
 approvers:
   - codificat
+  - harshad16
   - fridex
+  - goern
   - kpostoffice
   - mayacostantini
   - sesheta
 reviewers:
   - codificat
-  - mayacostantini
   - harshad16
+  - mayacostantini

--- a/thoth/adviser/unit.py
+++ b/thoth/adviser/unit.py
@@ -24,7 +24,6 @@ import re
 from typing import Any
 from typing import Dict
 from typing import Generator
-from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
@@ -35,7 +34,6 @@ import attr
 from voluptuous import Schema
 from voluptuous import Required
 from voluptuous import Any as SchemaAny
-from thoth.common import get_justification_link as jl
 from thoth.python import PackageVersion
 
 from .context import Context


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->

https://github.com/thoth-station/adviser/issues/2354#issuecomment-1171405051

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- No

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->

## This Pull Request implements
<!-- Provide a summary of your changes here. -->

This removes the `maintainers` section from `.thoth.yaml`.

Kebechet will pick up from the approvers list in `OWNERS`, removing redundancy and inconsistency.

Also updating the approvers list to include maintainers from `.thoth.yaml`