### PR TITLE
Moves flake8 config into a dedicated file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+ignore =
+    E2,
+    W5
+select =
+    E,
+    W,
+    F,
+    N
+max-line-length=120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,8 +48,6 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: ['pep8-naming']
-        # Ignore all format-related checks as Black takes care of those.
-        args: ['--ignore', 'E2,W5', '--select', 'E,W,F,N', '--max-line-length=120']
 
   - repo: https://github.com/mgedmin/check-manifest
     rev: '0.48'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.check-manifest]
+ignore = ['.flake8']


### PR DESCRIPTION
This allow to use the flake8 as part of the pre-commit hooks *and* with
other tool (in particular, the python-lsp-server).
