### PR TITLE
[WIP] Add metadata to advise results

### DIFF
--- a/thoth/adviser/report.py
+++ b/thoth/adviser/report.py
@@ -40,6 +40,7 @@ class Report:
 
     products = attr.ib(type=List[Product], kw_only=True)
     pipeline = attr.ib(type=PipelineConfig, kw_only=True)
+    report_metadata = attr.ib(type=dict, kw_only=True)
     resolver_iterations = attr.ib(type=int, kw_only=True, default=0)
     accepted_final_states_count = attr.ib(type=int, kw_only=True, default=0)
     discarded_final_states_count = attr.ib(type=int, kw_only=True, default=0)
@@ -71,4 +72,5 @@ class Report:
             "resolver_iterations": self.resolver_iterations,
             "accepted_final_states_count": self.accepted_final_states_count,
             "discarded_final_states_count": self.discarded_final_states_count,
+            "report_metadata": self.report_metadata,
         }


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/adviser/issues/2180

- [ ] make sure adviser provides tags/categories in metadata

## This introduces a breaking change

- Yes

Needs User API schema revision.

## This should yield a new module release

- Yes

## This Pull Request implements

Keep advise metadata in report (number of packages added / removed, number of justifications, advise id, `stack_info` count).
This Pull Request is a WIP and needs further testing.

If any metadata that it would be interesting to have is missing, please add it in a comment.
