### PR TITLE
turn validate-prescriptions into pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+- id: validate-prescriptions
+  name: Validating prescriptions
+  description: Validates Thoth prescriptions file
+  language: python
+  entry: thoth-adviser validate-prescriptions --pre-commit yes
+  types:
+    - file
+    - non-executable
+    - text
+    - yaml


### PR DESCRIPTION
- Make Presciption.validate error tolerant and report detailed errors
- Add pre-commit mode to validate-prescriptions and explicit files passing
- Pre-commit hook definition

## Related Issues and Dependencies
closes #2391
needs thoth-station/python#489 + a release to work

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- Yes

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->
