### PR TITLE
Fix test failures introduced by 613da05d

### DIFF
--- a/tests/boots/test_prescription_release.py
+++ b/tests/boots/test_prescription_release.py
@@ -35,7 +35,7 @@ class TestPrescriptionReleaseBoot(AdviserUnitTestCase):
         """Verify multiple should_include calls do not loop endlessly."""
         builder_context.recommendation_type = RecommendationType.LATEST
         prescription_path = str(self.data_dir / "prescriptions")
-        builder_context.prescription = Prescription.load(prescription_path)
+        builder_context.prescription = Prescription.load([prescription_path])
         self.verify_multiple_should_include(builder_context)
 
     def test_no_include(self, builder_context: PipelineBuilderContext) -> None:
@@ -46,7 +46,7 @@ class TestPrescriptionReleaseBoot(AdviserUnitTestCase):
     def test_should_include(self, builder_context: PipelineBuilderContext) -> None:
         """Test including this pipeline unit."""
         prescription_path = str(self.data_dir / "prescriptions")
-        builder_context.prescription = Prescription.load(prescription_path)
+        builder_context.prescription = Prescription.load([prescription_path])
         assert list(self.UNIT_TESTED.should_include(builder_context)) == [{}]
 
     def test_run(self, context: Context) -> None:
@@ -54,7 +54,7 @@ class TestPrescriptionReleaseBoot(AdviserUnitTestCase):
         assert not context.stack_info
 
         prescription_path = str(self.data_dir / "prescriptions")
-        context.prescription = Prescription.load(prescription_path)
+        context.prescription = Prescription.load([prescription_path])
 
         unit = self.UNIT_TESTED()
         unit.pre_run()

--- a/tests/prescription/v1/test_prescription.py
+++ b/tests/prescription/v1/test_prescription.py
@@ -33,7 +33,7 @@ class TestPrescription(AdviserTestCase):
     def test_load(self) -> None:
         """Test loading prescription."""
         prescription_path = str(self.data_dir / "prescriptions")
-        instance = Prescription.load(prescription_path)
+        instance = Prescription.load([prescription_path])
         assert instance is not None
         assert list(instance.boots_dict) == ["thoth.BootUnit"]
         assert list(instance.pseudonyms_dict) == ["thoth.PseudonymUnit"]


### PR DESCRIPTION
There was a slight change in the Prescription.load API, adjusting the
tests (Prescription.load does not appear to be used anywhere else)

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- Yes
