### PR TITLE
feat/remove custom validation use voluptous

### DIFF
--- a/tests/prescription/v1/test_prescription.py
+++ b/tests/prescription/v1/test_prescription.py
@@ -21,7 +21,6 @@ import pytest
 import yaml
 
 from thoth.adviser.exceptions import PrescriptionSchemaError
-from thoth.adviser.exceptions import PrescriptionDuplicateUnitNameError
 from thoth.adviser.prescription import Prescription
 
 from ...base import AdviserTestCase
@@ -69,7 +68,7 @@ class TestPrescription(AdviserTestCase):
             },
         }
 
-        with pytest.raises(PrescriptionDuplicateUnitNameError):
+        with pytest.raises(PrescriptionSchemaError):
             Prescription.from_dict(prescription, prescription_name="thoth", prescription_release="2021.06.15")
 
     def test_yaml_cloader(self) -> None:

--- a/thoth/adviser/exceptions.py
+++ b/thoth/adviser/exceptions.py
@@ -87,10 +87,6 @@ class PrescriptionSchemaError(PipelineUnitError):
     """An exception raised when prescription schema is not valid."""
 
 
-class PrescriptionDuplicateUnitNameError(PipelineUnitError):
-    """An exception raised when multiple prescription units share name."""
-
-
 class BootError(PipelineUnitError):
     """An exception raised when pipeline boot unit fails unexpectedly."""
 

--- a/thoth/adviser/prescription/v1/prescription.py
+++ b/thoth/adviser/prescription/v1/prescription.py
@@ -124,18 +124,6 @@ class Prescription:
         for unit in prescription_instance.units:
             any_error = any_error or cls._validate_run_base(unit)
 
-        for pseudonym in prescription_instance.pseudonyms_dict.values():
-            if pseudonym["run"]["yield"].get("yield_matched_version") and pseudonym["run"]["yield"][
-                "package_version"
-            ].get("locked_version"):
-                _LOGGER.error(
-                    "Error in unit %s (%s): Using 'yield_matched_version' together "
-                    "with 'locked_version' leads to undefined behavior",
-                    pseudonym["name"],
-                    pseudonym["type"],
-                )
-                any_error = True
-
         for step in prescription_instance.steps_dict.values():
             step_run = step["run"]
             msg = f"Error in unit {step['name']} ({step['type']})"

--- a/thoth/adviser/prescription/v1/prescription.py
+++ b/thoth/adviser/prescription/v1/prescription.py
@@ -98,34 +98,12 @@ class Prescription:
             self.wraps_dict.values(),
         )
 
-    @staticmethod
-    def _validate_run_base(unit: Dict[str, Any]) -> bool:
-        """Validate run for a pipeline unit."""
-        if unit.get("run", {}).get("eager_stop_pipeline") and unit.get("run", {}).get("not_acceptable"):
-            _LOGGER.error(
-                "Error in unit %s (%s): Using 'eager_stop_pipeline' and 'not_acceptable' at the same "
-                "time has undefined behavior",
-                unit["name"],
-                unit["type"],
-            )
-
-        return False
-
     @classmethod
     def validate(cls, prescriptions: Iterable[str], any_error_fatal: bool = True) -> "Prescription":
         """Validate the given prescription."""
         _LOGGER.debug("Validating prescriptions schema")
 
         prescription_instance = cls.load(prescriptions, any_error_fatal)
-
-        # Verify semantics of prescription.
-        any_error = False
-
-        for unit in prescription_instance.units:
-            any_error = any_error or cls._validate_run_base(unit)
-
-        if any_error:
-            raise PrescriptionSchemaError("Failed to validate prescription units, see logs reported for more info")
 
         # Drop any metadata associated to save space.
         for unit in prescription_instance.units:

--- a/thoth/adviser/prescription/v1/prescription.py
+++ b/thoth/adviser/prescription/v1/prescription.py
@@ -124,29 +124,6 @@ class Prescription:
         for unit in prescription_instance.units:
             any_error = any_error or cls._validate_run_base(unit)
 
-        for step in prescription_instance.steps_dict.values():
-            step_run = step["run"]
-            msg = f"Error in unit {step['name']} ({step['type']})"
-
-            if step_run.get("eager_stop_pipeline") and step_run.get("justification"):
-                _LOGGER.error(
-                    "%s: Using 'eager_stop_pipeline' together with 'justification' leads to undefined behavior", msg
-                )
-                any_error = True
-
-            if step_run.get("not_acceptable") and step_run.get("justification"):
-                _LOGGER.error(
-                    "%s: Using 'not_acceptable' together with 'justification' leads to undefined behavior", msg
-                )
-
-            if step_run.get("eager_stop_pipeline") and step_run.get("score") is not None:
-                _LOGGER.error("%s: Using 'eager_stop_pipeline' together with 'score' leads to undefined behavior", msg)
-                any_error = True
-
-            if step_run.get("not_acceptable") and step_run.get("score") is not None:
-                _LOGGER.error("%s: Using 'not_acceptable' together with 'score' leads to undefined behavior", msg)
-                any_error = True
-
         for wrap in prescription_instance.wraps_dict.values():
             wrap_run = wrap["run"]
             msg = f"Error in unit {wrap['name']} ({wrap['type']})"

--- a/thoth/adviser/prescription/v1/prescription.py
+++ b/thoth/adviser/prescription/v1/prescription.py
@@ -124,21 +124,6 @@ class Prescription:
         for unit in prescription_instance.units:
             any_error = any_error or cls._validate_run_base(unit)
 
-        for wrap in prescription_instance.wraps_dict.values():
-            wrap_run = wrap["run"]
-            msg = f"Error in unit {wrap['name']} ({wrap['type']})"
-
-            if wrap_run.get("eager_stop_pipeline") and wrap_run.get("justification"):
-                _LOGGER.error(
-                    "%s: Using 'eager_stop_pipeline' together with 'justification' leads to undefined behavior", msg
-                )
-                any_error = True
-
-            if wrap_run.get("not_acceptable") and wrap_run.get("justification"):
-                _LOGGER.error(
-                    "%s: Using 'not_acceptable' together with 'justification' leads to undefined behavior", msg
-                )
-
         if any_error:
             raise PrescriptionSchemaError("Failed to validate prescription units, see logs reported for more info")
 

--- a/thoth/adviser/prescription/v1/schema.py
+++ b/thoth/adviser/prescription/v1/schema.py
@@ -19,6 +19,7 @@
 
 import re
 from urllib.parse import urlparse
+import typing
 
 from voluptuous import All
 from voluptuous import Any
@@ -313,13 +314,22 @@ PRESCRIPTION_BOOT_SCHEMA = Schema(
 
 PRESCRIPTION_PSEUDONYM_MATCH_ENTRY_SCHEMA = Schema({"package_version": PACKAGE_VERSION_REQUIRED_NAME_SCHEMA})
 
+
+def _version_yield_vs_locked(pseudonym: typing.Dict[str, typing.Any]) -> None:
+    if pseudonym.get("yield_matched_version") and pseudonym["package_version"].get("locked_version"):
+        raise ValueError("'yield_matched_version' together " "with 'locked_version' leads to undefined behavior")
+
+
 PRESCRIPTION_PSEUDONYM_RUN_SCHEMA = Schema(
     {
         Required("yield"): Schema(
-            {
-                Optional("yield_matched_version"): bool,
-                "package_version": PACKAGE_VERSION_LOCKED_SCHEMA,
-            }
+            All(
+                {
+                    Optional("yield_matched_version"): bool,
+                    "package_version": PACKAGE_VERSION_LOCKED_SCHEMA,
+                },
+                _version_yield_vs_locked,
+            )
         ),
         **_UNIT_RUN_SCHEMA_BASE_DICT,
     }

--- a/thoth/adviser/prescription/v1/schema.py
+++ b/thoth/adviser/prescription/v1/schema.py
@@ -619,27 +619,42 @@ PRESCRIPTION_GH_RELEASE_NOTES_WRAP_SCHEMA = _BASE_UNIT_SCHEMA.extend(
 # Prescription.
 #
 
-PRESCRIPTION_UNITS_SCHEMA = Schema(
-    {
-        Optional("boots"): [PRESCRIPTION_BOOT_SCHEMA],
-        Optional("sieves"): [Any(PRESCRIPTION_SIEVE_SCHEMA, PRESCRIPTION_SKIP_PACKAGE_SIEVE_SCHEMA)],
-        Optional("steps"): [
-            Any(
-                PRESCRIPTION_STEP_SCHEMA,
-                PRESCRIPTION_SKIP_PACKAGE_STEP_SCHEMA,
-                PRESCRIPTION_ADD_PACKAGE_STEP_SCHEMA,
-                PRESCRIPTION_GROUP_STEP_SCHEMA,
-            )
-        ],
-        Optional("pseudonyms"): [PRESCRIPTION_PSEUDONYM_SCHEMA],
-        Optional("strides"): [PRESCRIPTION_STRIDE_SCHEMA],
-        Optional("wraps"): [
-            Any(
-                PRESCRIPTION_WRAP_SCHEMA,
-                PRESCRIPTION_GH_RELEASE_NOTES_WRAP_SCHEMA,
-            )
-        ],
-    }
+
+def _unique_by_name(units: typing.Dict[str, Any]) -> typing.Dict[str, Any]:
+    for _type, _list in units.items():
+        _units = set()
+        for unit in _list:
+            if unit["name"] in _units:
+                raise ValueError(f"{_type[:-1].capitalize()} with name {unit['name']} is already present")
+            else:
+                _units.add(unit["name"])
+        return units
+
+
+PRESCRIPTION_UNITS_SCHEMA = All(
+    Schema(
+        {
+            Optional("boots"): [PRESCRIPTION_BOOT_SCHEMA],
+            Optional("sieves"): [Any(PRESCRIPTION_SIEVE_SCHEMA, PRESCRIPTION_SKIP_PACKAGE_SIEVE_SCHEMA)],
+            Optional("steps"): [
+                Any(
+                    PRESCRIPTION_STEP_SCHEMA,
+                    PRESCRIPTION_SKIP_PACKAGE_STEP_SCHEMA,
+                    PRESCRIPTION_ADD_PACKAGE_STEP_SCHEMA,
+                    PRESCRIPTION_GROUP_STEP_SCHEMA,
+                )
+            ],
+            Optional("pseudonyms"): [PRESCRIPTION_PSEUDONYM_SCHEMA],
+            Optional("strides"): [PRESCRIPTION_STRIDE_SCHEMA],
+            Optional("wraps"): [
+                Any(
+                    PRESCRIPTION_WRAP_SCHEMA,
+                    PRESCRIPTION_GH_RELEASE_NOTES_WRAP_SCHEMA,
+                )
+            ],
+        }
+    ),
+    _unique_by_name,
 )
 
 PRESCRIPTION_SCHEMA = Schema(

--- a/thoth/adviser/prescription/v1/schema.py
+++ b/thoth/adviser/prescription/v1/schema.py
@@ -254,6 +254,13 @@ _UNIT_RUN_SCHEMA_BASE = Schema(
     }
 )
 
+_UNIT_RUN_NOT_ACCEPT = _UNIT_RUN_SCHEMA_BASE.extend(
+    {
+        Exclusive("not_acceptable", "not_accept+eager"): _NONEMPTY_STRING,
+        Exclusive("eager_stop_pipeline", "not_accept+eager"): _NONEMPTY_STRING,
+    }
+)
+
 
 def _locked_version(v: object) -> None:
     """Validate locked version."""
@@ -295,12 +302,7 @@ PACKAGE_VERSION_REQUIRED_NAME_SCHEMA = Schema(
 
 PRESCRIPTION_BOOT_MATCH_ENTRY_SCHEMA = Schema({"package_name": Optional(_NONEMPTY_STRING)})
 
-PRESCRIPTION_BOOT_RUN_SCHEMA = _UNIT_RUN_SCHEMA_BASE.extend(
-    {
-        Optional("not_acceptable"): _NONEMPTY_STRING,
-        Optional("eager_stop_pipeline"): _NONEMPTY_STRING,
-    }
-)
+PRESCRIPTION_BOOT_RUN_SCHEMA = _UNIT_RUN_NOT_ACCEPT
 
 PRESCRIPTION_BOOT_SCHEMA = _BASE_UNIT_SCHEMA.extend(
     {
@@ -408,7 +410,7 @@ PRESCRIPTION_STEP_MATCH_ENTRY_SCHEMA = Schema(
 )
 
 PRESCRIPTION_STEP_RUN_SCHEMA = All(
-    _UNIT_RUN_SCHEMA_BASE.extend(
+    _UNIT_RUN_NOT_ACCEPT.extend(
         {
             Exclusive("score", "score+eager"): Optional(float),
             Exclusive("justification", "justi+not_acceptable"): All([JUSTIFICATION_SCHEMA], Length(min=1)),
@@ -500,12 +502,10 @@ PRESCRIPTION_ADD_PACKAGE_STEP_SCHEMA = _BASE_UNIT_SCHEMA.extend(
 # Group step unit.
 #
 
-PRESCRIPTION_GROUP_STEP_RUN_SCHEMA = _UNIT_RUN_SCHEMA_BASE.extend(
+PRESCRIPTION_GROUP_STEP_RUN_SCHEMA = _UNIT_RUN_NOT_ACCEPT.extend(
     {
         Optional("score"): Optional(float),
         Optional("justification"): All([JUSTIFICATION_SCHEMA], Length(min=1)),
-        Optional("not_acceptable"): _NONEMPTY_STRING,
-        Optional("eager_stop_pipeline"): _NONEMPTY_STRING,
     }
 )
 
@@ -535,12 +535,7 @@ PRESCRIPTION_STRIDE_MATCH_ENTRY_SCHEMA = Schema(
     {Required("state"): Schema({Required("resolved_dependencies"): [PACKAGE_VERSION_SCHEMA]})}
 )
 
-PRESCRIPTION_STRIDE_RUN_SCHEMA = _UNIT_RUN_SCHEMA_BASE.extend(
-    {
-        Optional("not_acceptable"): _NONEMPTY_STRING,
-        Optional("eager_stop_pipeline"): _NONEMPTY_STRING,
-    }
-)
+PRESCRIPTION_STRIDE_RUN_SCHEMA = _UNIT_RUN_NOT_ACCEPT
 
 PRESCRIPTION_STRIDE_SCHEMA = _BASE_UNIT_SCHEMA.extend(
     {

--- a/thoth/adviser/prescription/v1/schema.py
+++ b/thoth/adviser/prescription/v1/schema.py
@@ -26,6 +26,8 @@ from voluptuous import Any
 from voluptuous import Invalid
 from voluptuous import Length
 from voluptuous import Optional
+from voluptuous import Exclusive
+from voluptuous import Extra
 from voluptuous import Range
 from voluptuous import Required
 from voluptuous import Schema
@@ -417,14 +419,23 @@ PRESCRIPTION_STEP_MATCH_ENTRY_SCHEMA = Schema(
 )
 
 PRESCRIPTION_STEP_RUN_SCHEMA = Schema(
-    {
-        Optional("score"): Optional(float),
-        Optional("justification"): All([JUSTIFICATION_SCHEMA], Length(min=1)),
-        Optional("not_acceptable"): _NONEMPTY_STRING,
-        Optional("eager_stop_pipeline"): _NONEMPTY_STRING,
-        Optional("multi_package_resolution"): bool,
-        **_UNIT_RUN_SCHEMA_BASE_DICT,
-    }
+    All(
+        {
+            Exclusive("score", "score+eager"): Optional(float),
+            Exclusive("justification", "justi+not_acceptable"): All([JUSTIFICATION_SCHEMA], Length(min=1)),
+            Exclusive("not_acceptable", "justi+not_acceptable"): _NONEMPTY_STRING,
+            Exclusive("eager_stop_pipeline", "score+eager"): _NONEMPTY_STRING,
+            Optional("multi_package_resolution"): bool,
+            **_UNIT_RUN_SCHEMA_BASE_DICT,
+        },
+        {
+            Extra: object,
+            Exclusive("eager_stop_pipeline", "justi+eager"): object,
+            Exclusive("justification", "justi+eager"): object,
+            Exclusive("score", "score+not_acceptable"): object,
+            Exclusive("not_acceptable", "score+not_acceptable"): object,
+        },
+    )
 )
 
 PRESCRIPTION_STEP_SCHEMA = Schema(


### PR DESCRIPTION
## Related Issues and Dependencies
closes #2407

## This introduces a breaking change
<!-- Leave one of the options -->

- Yes

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

PrescriptionDuplicateUnitNameError is removed and incorporated in PrescriptionSchemaError

## This should yield a new module release

- Yes

### Description

Get rid of a bunch of manual code and put all schema semantics **inside** the voluptous schema.

This should avoid disconnection between the schema and the validation logic (discovered at least one while working on that) reduce our maintenance cost.
