### PR TITLE
Disable Kebechet pipfile-requirements manager

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -11,7 +11,6 @@ runtime_environments:
     recommendation_type: latest
 
 managers:
-  - name: pipfile-requirements
   - name: update
     configuration:
       labels: [bot]


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->

Closes #2422

Related to #2411

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- No

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->

## This Pull Request implements
<!-- Provide a summary of your changes here. -->

Disable Kebechet's [pipfile-requirements manager](https://thoth-station.ninja/docs/developers/kebechet/managers/pipfile_requirements.html) in the repo, as there is no `requirements.txt` here anymore.